### PR TITLE
added command timeout

### DIFF
--- a/Respawn/Checkpoint.cs
+++ b/Respawn/Checkpoint.cs
@@ -16,6 +16,7 @@ namespace Respawn
         public string[] SchemasToInclude { get; set; } = new string[0];
         public string[] SchemasToExclude { get; set; } = new string[0];
         public IDbAdapter DbAdapter { get; set; } = Respawn.DbAdapter.SqlServer;
+        public int? CommandTimeout { get; set; }
 
         private class Relationship
         {
@@ -50,6 +51,7 @@ namespace Respawn
             using (var tx = connection.BeginTransaction())
             using (var cmd = connection.CreateCommand())
             {
+                cmd.CommandTimeout = CommandTimeout ?? cmd.CommandTimeout;
                 cmd.CommandText = _deleteSql;
                 cmd.Transaction = tx;
 


### PR DESCRIPTION
Sometimes our local dev db gets a restore from production and it takes too long to delete all the data with the  default commandtimeout. This lets the user configure the command timeout in order to delete large datasets. This could also be useful for perf testing. 