### PR TITLE
Changed Tests framework version to 4.5 and added Unit Test project template

### DIFF
--- a/Respawn.Tests/App.config
+++ b/Respawn.Tests/App.config
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <system.data>
     <DbProviderFactories>
-      <add name="Npgsql Data Provider"
-           invariant="Npgsql2"
-           support="FF"
-           description=".Net Framework Data Provider for Postgresql Server"
-           type="Npgsql.NpgsqlFactory, Npgsql" />
+      <add name="Npgsql Data Provider" invariant="Npgsql2" support="FF" description=".Net Framework Data Provider for Postgresql Server" type="Npgsql.NpgsqlFactory, Npgsql"/>
     </DbProviderFactories>
   </system.data>
-</configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup></configuration>

--- a/Respawn.Tests/App.config
+++ b/Respawn.Tests/App.config
@@ -1,8 +1,12 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
   <system.data>
     <DbProviderFactories>
-      <add name="Npgsql Data Provider" invariant="Npgsql2" support="FF" description=".Net Framework Data Provider for Postgresql Server" type="Npgsql.NpgsqlFactory, Npgsql"/>
+      <add name="Npgsql Data Provider"
+           invariant="Npgsql2"
+           support="FF"
+           description=".Net Framework Data Provider for Postgresql Server"
+           type="Npgsql.NpgsqlFactory, Npgsql" />
     </DbProviderFactories>
   </system.data>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup></configuration>

--- a/Respawn.Tests/PostgresTests.cs
+++ b/Respawn.Tests/PostgresTests.cs
@@ -4,6 +4,7 @@
     using Npgsql;
     using NPoco;
     using Shouldly;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
 
     public class PostgresTests : IDisposable
     {
@@ -38,6 +39,7 @@
             _database = new Database(_connection, DatabaseType.PostgreSQL);
         }
 
+        [TestMethod]
         public void ShouldDeleteData()
         {
             _database.Execute("create table \"foo\" (value int)");
@@ -59,6 +61,7 @@
             _database.ExecuteScalar<int>("SELECT COUNT(1) FROM \"foo\"").ShouldBe(0);
         }
 
+        [TestMethod]
         public void ShouldIgnoreTables()
         {
             _database.Execute("create table foo (value int)");
@@ -82,6 +85,7 @@
             _database.ExecuteScalar<int>("SELECT COUNT(1) FROM bar").ShouldBe(0);
         }
 
+        [TestMethod]
         public void ShouldExcludeSchemas()
         {
             _database.Execute("create schema a");
@@ -106,6 +110,7 @@
             _database.ExecuteScalar<int>("SELECT COUNT(1) FROM b.bar").ShouldBe(0);
         }
 
+        [TestMethod]
         public void ShouldIncludeSchemas()
         {
             _database.Execute("create schema a");
@@ -132,6 +137,7 @@
 
 
 
+        [TestCleanup]
         public void Dispose()
         {
             _database.Dispose();

--- a/Respawn.Tests/Respawn.Tests.csproj
+++ b/Respawn.Tests/Respawn.Tests.csproj
@@ -14,6 +14,7 @@
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
     <TargetFrameworkProfile />
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Respawn.Tests/Respawn.Tests.csproj
+++ b/Respawn.Tests/Respawn.Tests.csproj
@@ -37,6 +37,7 @@
     <Reference Include="Fixie">
       <HintPath>..\packages\Fixie.1.0.0.3\lib\net45\Fixie.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
     <Reference Include="Mono.Security">
       <HintPath>..\packages\Npgsql.2.2.4.3\lib\net45\Mono.Security.dll</HintPath>
     </Reference>

--- a/Respawn.Tests/Respawn.Tests.csproj
+++ b/Respawn.Tests/Respawn.Tests.csproj
@@ -9,10 +9,11 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Respawn.Tests</RootNamespace>
     <AssemblyName>Respawn.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.3</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Respawn.Tests/SqlServerTests.cs
+++ b/Respawn.Tests/SqlServerTests.cs
@@ -6,6 +6,7 @@
     using System.Linq;
     using NPoco;
     using Shouldly;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
 
     public class SqlServerTests : IDisposable
     {
@@ -41,6 +42,7 @@
             _database.Execute("create database [SqlServerTests]");
         }
 
+        [TestMethod]
         public void ShouldDeleteData()
         {
             _database.Execute("create table Foo (Value [int])");
@@ -55,6 +57,7 @@
             _database.ExecuteScalar<int>("SELECT COUNT(1) FROM Foo").ShouldBe(0);
         }
 
+        [TestMethod]
         public void ShouldIgnoreTables()
         {
             _database.Execute("create table Foo (Value [int])");
@@ -73,6 +76,7 @@
             _database.ExecuteScalar<int>("SELECT COUNT(1) FROM Bar").ShouldBe(0);
         }
 
+        [TestMethod]
         public void ShouldExcludeSchemas()
         {
             _database.Execute("create schema A");
@@ -96,6 +100,7 @@
             _database.ExecuteScalar<int>("SELECT COUNT(1) FROM B.Bar").ShouldBe(0);
         }
 
+        [TestMethod]
         public void ShouldIncludeSchemas()
         {
             _database.Execute("create schema A");
@@ -121,6 +126,7 @@
 
 
 
+        [TestCleanup]
         public void Dispose()
         {
             _database.Execute("drop database [SqlServerTests]");

--- a/Respawn/Checkpoint.cs
+++ b/Respawn/Checkpoint.cs
@@ -12,10 +12,10 @@ namespace Respawn
         private string[] _tablesToDelete;
         private string _deleteSql;
 
-        public string[] TablesToIgnore { get; set; } = new string[0];
-        public string[] SchemasToInclude { get; set; } = new string[0];
-        public string[] SchemasToExclude { get; set; } = new string[0];
-        public IDbAdapter DbAdapter { get; set; } = Respawn.DbAdapter.SqlServer;
+        public string[] TablesToIgnore { get; set; }
+        public string[] SchemasToInclude { get; set; }
+        public string[] SchemasToExclude { get; set; }
+        public IDbAdapter DbAdapter { get; set; }
         public int? CommandTimeout { get; set; }
 
         private class Relationship
@@ -23,7 +23,18 @@ namespace Respawn
             public string PrimaryKeyTable { get; set; }
             public string ForeignKeyTable { get; set; }
 
-            public bool IsSelfReferencing => PrimaryKeyTable == ForeignKeyTable;
+            public bool IsSelfReferencing
+            {
+                get { return PrimaryKeyTable == ForeignKeyTable; }
+            }
+        }
+
+        public Checkpoint()
+        {
+            TablesToIgnore = new string[0];
+            SchemasToInclude = new string[0];
+            SchemasToExclude = new string[0];
+            DbAdapter = Respawn.DbAdapter.SqlServer;
         }
 
         public virtual void Reset(string nameOrConnectionString)


### PR DESCRIPTION
I tried to open project from Visual Studio 2015 CTP but couldn't because it ask for framework version 4.5.3. Then I tried to download that version but I couldn't find it. Later I found that this version name can be changed to 4.6 in [different versions of Visual Studio](https://msdn.microsoft.com/en-us/library/5a4x27ek%28v=vs.110%29.aspx). To able to work with all versions of Visual Studio 2015, I changed target framework version to 4.5.

After tried to build solution in Visual Studio 2013, I noticed that Checkpoint class contains C# 6.0 specific code which can be easily changed to C# 5.0. Since most developers still use Visual Studio 2013, I updated code to the compatibility.
