### PR TITLE
Improve error message with data and suggestion.

### DIFF
--- a/Respawn/Checkpoint.cs
+++ b/Respawn/Checkpoint.cs
@@ -90,7 +90,11 @@ namespace Respawn
 
             if (referencedTables.Count > 0 && leafTables.Count == 0)
             {
-                throw new InvalidOperationException("There is a circular dependency between the DB tables and we can't safely build the list of tables to delete.");
+                string message = string.Join(",", referencedTables);
+                message = string.Join(Environment.NewLine, $@"There is a dependency involving the DB tables ({message}) and we can't safely build the list of tables to delete.",
+                    "Check for circular references.",
+                    "If you have TablesToIgnore you also need to ignore the tables to which these have primary key relationships.");
+                throw new InvalidOperationException(message);
             }
 
             tablesToDelete.AddRange(leafTables);


### PR DESCRIPTION
I had added a couple tables to theTablesToIgnore and had accidentally left the brackets that I copied from SQL on there:

`TablesToIgnore = new[] { "sysdiagrams", "Table1", "[Table2]" }`

This caused an error that claimed a circular reference which is actually is not the case.  I updated the error message to include the names of the tables that are causing the conflict and offer a suggestion of the potential problem.