### PR TITLE
New Feature: MySQL Support

### DIFF
--- a/Respawn.Tests/MySqlTests.cs
+++ b/Respawn.Tests/MySqlTests.cs
@@ -33,7 +33,7 @@ namespace Respawn.Tests
             var connString =
                 isAppVeyor
                     ? @"Server=127.0.0.1; port = 3306; User Id = root; Password = Password12!"
-                    : @"Server=127.0.0.1; port = 3306; User Id = root; Password = password";
+                    : @"Server=127.0.0.1; port = 3306; User Id = root; Password = Password12!";
 
             _connection = new MySqlConnection(connString);
             _connection.Open();
@@ -49,7 +49,7 @@ namespace Respawn.Tests
         public async Task ShouldDeleteData()
         {
             _database.Execute("drop table if exists Foo");
-            _database.Execute("CREATE TABLE `Foo` (`Value` int(11))");
+            _database.Execute("CREATE TABLE `Foo` (`Value` int(3))");
 
             _database.InsertBulk(Enumerable.Range(0, 100).Select(i => new Foo { Value = i }));
 
@@ -69,8 +69,8 @@ namespace Respawn.Tests
         {
             _database.Execute("drop table if exists Foo");
             _database.Execute("drop table if exists Bar");
-            _database.Execute("create table `Foo` (`Value` int(11))");
-            _database.Execute("create table `Bar` (`Value` int(11))");
+            _database.Execute("create table `Foo` (`Value` int(3))");
+            _database.Execute("create table `Bar` (`Value` int(3))");
 
             _database.InsertBulk(Enumerable.Range(0, 100).Select(i => new Foo { Value = i }));
             _database.InsertBulk(Enumerable.Range(0, 100).Select(i => new Bar { Value = i }));
@@ -95,8 +95,8 @@ namespace Respawn.Tests
             _database.Execute("drop schema if exists `B`");
             _database.Execute("create schema `A`");
             _database.Execute("create schema `B`");
-            _database.Execute("create table `A`.`Foo` (`Value` int)");
-            _database.Execute("create table `B`.`Bar` (`Value` int)");
+            _database.Execute("create table `A`.`Foo` (`Value` int(3))");
+            _database.Execute("create table `B`.`Bar` (`Value` int(3))");
 
             for (int i = 0; i < 100; i++)
             {
@@ -124,8 +124,8 @@ namespace Respawn.Tests
             _database.Execute("drop schema if exists `B`");
             _database.Execute("create schema `A`");
             _database.Execute("create schema `B`");
-            _database.Execute("create table `A`.`Foo` (`Value` int)");
-            _database.Execute("create table `B`.`Bar` (`Value` int)");
+            _database.Execute("create table `A`.`Foo` (`Value` int(3))");
+            _database.Execute("create table `B`.`Bar` (`Value` int(3))");
 
             for (int i = 0; i < 100; i++)
             {

--- a/Respawn.Tests/MySqlTests.cs
+++ b/Respawn.Tests/MySqlTests.cs
@@ -1,0 +1,156 @@
+﻿using System.Data.Common;
+using System.Data.SqlClient;
+using System.Globalization;
+using System.Threading.Tasks;
+using MySql.Data.MySqlClient;
+using Xunit;
+
+namespace Respawn.Tests
+{
+    using System;
+    using System.Linq;
+    using NPoco;
+    using Shouldly;
+
+    public class MySqlTests : IDisposable
+    {
+        private MySqlConnection _connection;
+        private readonly IDatabase _database;
+        
+        public class Foo
+        {
+            public int Value { get; set; }
+        }
+        public class Bar
+        {
+            public int Value { get; set; }
+        }
+
+        public MySqlTests()
+        {
+            var isAppVeyor = Environment.GetEnvironmentVariable("Appveyor")?.ToUpperInvariant() == "TRUE";
+
+            var connString =
+                isAppVeyor
+                    ? @"Server=127.0.0.1; port = 3306; User Id = root; Password = Password12!"
+                    : @"Server=127.0.0.1; port = 3306; User Id = root; Password = password";
+
+            _connection = new MySqlConnection(connString);
+            _connection.Open();
+            
+            _database = new Database(_connection);
+
+            _database.Execute(@"DROP DATABASE IF EXISTS MySqlTests");
+            _database.Execute("create database MySqlTests");
+            _database.Execute("use MySqlTests");
+        }
+
+        [Fact]
+        public async Task ShouldDeleteData()
+        {
+            _database.Execute("drop table if exists Foo");
+            _database.Execute("CREATE TABLE `Foo` (`Value` int(11))");
+
+            _database.InsertBulk(Enumerable.Range(0, 100).Select(i => new Foo { Value = i }));
+
+            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM Foo").ShouldBe(100);
+
+            var checkpoint = new Checkpoint()
+            {
+                DbAdapter = DbAdapter.MySql
+            };
+            await checkpoint.Reset(_connection);
+
+            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM Foo").ShouldBe(0);
+        }
+
+        [Fact]
+        public async Task ShouldIgnoreTables()
+        {
+            _database.Execute("drop table if exists Foo");
+            _database.Execute("drop table if exists Bar");
+            _database.Execute("create table `Foo` (`Value` int(11))");
+            _database.Execute("create table `Bar` (`Value` int(11))");
+
+            _database.InsertBulk(Enumerable.Range(0, 100).Select(i => new Foo { Value = i }));
+            _database.InsertBulk(Enumerable.Range(0, 100).Select(i => new Bar { Value = i }));
+
+            var checkpoint = new Checkpoint
+            {
+                DbAdapter = DbAdapter.MySql,
+                TablesToIgnore = new[] { "Foo" }
+            };
+            await checkpoint.Reset(_connection);
+
+            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM Foo").ShouldBe(100);
+            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM Bar").ShouldBe(0);
+        }
+
+        [Fact]
+        public async Task ShouldExcludeSchemas()
+        {
+            _database.Execute("drop table if exists `A`.`Foo`");
+            _database.Execute("drop table if exists `B`.`Bar`");
+            _database.Execute("drop schema if exists `A`");
+            _database.Execute("drop schema if exists `B`");
+            _database.Execute("create schema `A`");
+            _database.Execute("create schema `B`");
+            _database.Execute("create table `A`.`Foo` (`Value` int)");
+            _database.Execute("create table `B`.`Bar` (`Value` int)");
+
+            for (int i = 0; i < 100; i++)
+            {
+                _database.Execute("INSERT `A`.`Foo` VALUES (" + i + ")");
+                _database.Execute("INSERT `B`.`Bar` VALUES (" + i + ")");
+            }
+
+            var checkpoint = new Checkpoint
+            {
+                DbAdapter = DbAdapter.MySql,
+                SchemasToExclude = new[] { "A" }
+            };
+            await checkpoint.Reset(_connection);
+
+            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM A.Foo").ShouldBe(100);
+            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM B.Bar").ShouldBe(0);
+        }
+
+        [Fact]
+        public async Task ShouldIncludeSchemas()
+        {
+            _database.Execute("drop table if exists `A`.`Foo`");
+            _database.Execute("drop table if exists `B`.`Bar`");
+            _database.Execute("drop schema if exists `A`");
+            _database.Execute("drop schema if exists `B`");
+            _database.Execute("create schema `A`");
+            _database.Execute("create schema `B`");
+            _database.Execute("create table `A`.`Foo` (`Value` int)");
+            _database.Execute("create table `B`.`Bar` (`Value` int)");
+
+            for (int i = 0; i < 100; i++)
+            {
+                _database.Execute("INSERT A.Foo VALUES (" + i + ")");
+                _database.Execute("INSERT B.Bar VALUES (" + i + ")");
+            }
+
+            var checkpoint = new Checkpoint
+            {
+                DbAdapter = DbAdapter.MySql,
+                SchemasToInclude = new[] { "B" }
+            };
+            await checkpoint.Reset(_connection);
+
+            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM A.Foo").ShouldBe(100);
+            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM B.Bar").ShouldBe(0);
+        }
+
+
+
+        public void Dispose()
+        {
+            _connection.Close();
+            _connection.Dispose();
+            _connection = null;
+        }
+    }
+}

--- a/Respawn.Tests/MySqlTests.cs
+++ b/Respawn.Tests/MySqlTests.cs
@@ -1,7 +1,4 @@
-﻿using System.Data.Common;
-using System.Data.SqlClient;
-using System.Globalization;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using MySql.Data.MySqlClient;
 using Xunit;
 
@@ -143,8 +140,6 @@ namespace Respawn.Tests
             _database.ExecuteScalar<int>("SELECT COUNT(1) FROM A.Foo").ShouldBe(100);
             _database.ExecuteScalar<int>("SELECT COUNT(1) FROM B.Bar").ShouldBe(0);
         }
-
-
 
         public void Dispose()
         {

--- a/Respawn.Tests/Respawn.Tests.csproj
+++ b/Respawn.Tests/Respawn.Tests.csproj
@@ -5,6 +5,7 @@
     <AssemblyName>Respawn.Tests</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="MySql.Data" Version="6.10.4" />
     <PackageReference Include="Npgsql" Version="3.2.5" />
     <PackageReference Include="NPoco" Version="3.8.0" />
     <PackageReference Include="Shouldly" Version="3.0.0-beta0003" />

--- a/Respawn/Checkpoint.cs
+++ b/Respawn/Checkpoint.cs
@@ -126,8 +126,8 @@ namespace Respawn
                     {
                         var rel = new Relationship
                         {
-                            PrimaryKeyTable = CorrectSqlQuotes("\"" + reader.GetString(0) + "\".\"" + reader.GetString(1) + "\""),
-                            ForeignKeyTable = CorrectSqlQuotes("\"" + reader.GetString(2) + "\".\"" + reader.GetString(3) + "\"")
+                            PrimaryKeyTable = $"{DbAdapter.QuoteCharacter}{reader.GetString(0)}{DbAdapter.QuoteCharacter}.{DbAdapter.QuoteCharacter}{reader.GetString(1)}",
+                            ForeignKeyTable = $"{DbAdapter.QuoteCharacter}{reader.GetString(2)}{DbAdapter.QuoteCharacter}.{DbAdapter.QuoteCharacter}{reader.GetString(3)}{DbAdapter.QuoteCharacter}"
                         };
                         rels.Add(rel);
                     }
@@ -152,22 +152,17 @@ namespace Respawn
                     {
                         if (!await reader.IsDBNullAsync(0))
                         {
-                            tables.Add(CorrectSqlQuotes("\"" + reader.GetString(0) + "\".\"" + reader.GetString(1) + "\""));
+                            tables.Add($"{DbAdapter.QuoteCharacter}{reader.GetString(0)}{DbAdapter.QuoteCharacter}.{DbAdapter.QuoteCharacter}{reader.GetString(1)}{DbAdapter.QuoteCharacter}");
                         }
                         else
                         {
-                            tables.Add(CorrectSqlQuotes("\"" + reader.GetString(1) + "\""));
+                            tables.Add($"{DbAdapter.QuoteCharacter}{reader.GetString(1)}{DbAdapter.QuoteCharacter}");
                         }
                     }
                 }
             }
 
             return tables.ToList();
-        }
-
-        private string CorrectSqlQuotes(string input)
-        {
-            return input.Replace('"', DbAdapter.QuoteCharacter);
         }
     }
 }

--- a/Respawn/Checkpoint.cs
+++ b/Respawn/Checkpoint.cs
@@ -126,7 +126,7 @@ namespace Respawn
                     {
                         var rel = new Relationship
                         {
-                            PrimaryKeyTable = $"{DbAdapter.QuoteCharacter}{reader.GetString(0)}{DbAdapter.QuoteCharacter}.{DbAdapter.QuoteCharacter}{reader.GetString(1)}",
+                            PrimaryKeyTable = $"{DbAdapter.QuoteCharacter}{reader.GetString(0)}{DbAdapter.QuoteCharacter}.{DbAdapter.QuoteCharacter}{reader.GetString(1)}{DbAdapter.QuoteCharacter}",
                             ForeignKeyTable = $"{DbAdapter.QuoteCharacter}{reader.GetString(2)}{DbAdapter.QuoteCharacter}.{DbAdapter.QuoteCharacter}{reader.GetString(3)}{DbAdapter.QuoteCharacter}"
                         };
                         rels.Add(rel);

--- a/Respawn/Checkpoint.cs
+++ b/Respawn/Checkpoint.cs
@@ -126,8 +126,8 @@ namespace Respawn
                     {
                         var rel = new Relationship
                         {
-                            PrimaryKeyTable = "\"" + reader.GetString(0) + "\".\"" + reader.GetString(1) + "\"",
-                            ForeignKeyTable = "\"" + reader.GetString(2) + "\".\"" + reader.GetString(3) + "\""
+                            PrimaryKeyTable = CorrectSqlQuotes("\"" + reader.GetString(0) + "\".\"" + reader.GetString(1) + "\""),
+                            ForeignKeyTable = CorrectSqlQuotes("\"" + reader.GetString(2) + "\".\"" + reader.GetString(3) + "\"")
                         };
                         rels.Add(rel);
                     }
@@ -152,17 +152,22 @@ namespace Respawn
                     {
                         if (!await reader.IsDBNullAsync(0))
                         {
-                            tables.Add("\"" + reader.GetString(0) + "\".\"" + reader.GetString(1) + "\"");
+                            tables.Add(CorrectSqlQuotes("\"" + reader.GetString(0) + "\".\"" + reader.GetString(1) + "\""));
                         }
                         else
                         {
-                            tables.Add("\"" + reader.GetString(1) + "\"");
+                            tables.Add(CorrectSqlQuotes("\"" + reader.GetString(1) + "\""));
                         }
                     }
                 }
             }
 
             return tables.ToList();
+        }
+
+        private string CorrectSqlQuotes(string input)
+        {
+            return input.Replace('"', DbAdapter.QuoteCharacter);
         }
     }
 }

--- a/Respawn/DbAdapter.cs
+++ b/Respawn/DbAdapter.cs
@@ -273,10 +273,10 @@ WHERE
             public string BuildRelationshipCommandText(Checkpoint checkpoint)
             {
                 var commandText = @"
-SELECT CONSTRAINT_SCHEMA, 
-    TABLE_NAME, 
-    UNIQUE_CONSTRAINT_SCHEMA, 
-    REFERENCED_TABLE_NAME 
+SELECT UNIQUE_CONSTRAINT_SCHEMA, 
+    REFERENCED_TABLE_NAME, 
+    CONSTRAINT_SCHEMA, 
+    TABLE_NAME 
 FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS";
 
                 var whereText = new List<string>();

--- a/Respawn/DbAdapter.cs
+++ b/Respawn/DbAdapter.cs
@@ -240,13 +240,13 @@ where 1=1";
 
             public string BuildTableCommandText(Checkpoint checkpoint)
             {
-                string commandText = @"SELECT 
-                                        t.TABLE_SCHEMA, t.TABLE_NAME
-                                       FROM
-                                        information_schema.tables AS t
-                                       WHERE
-                                        table_type = 'BASE TABLE'
-                                       AND TABLE_SCHEMA NOT IN ('mysql' , 'performance_schema')";
+                string commandText = @"
+SELECT t.TABLE_SCHEMA, t.TABLE_NAME
+FROM
+    information_schema.tables AS t
+WHERE
+    table_type = 'BASE TABLE'
+    AND TABLE_SCHEMA NOT IN ('mysql' , 'performance_schema')";
 
                 if (checkpoint.TablesToIgnore != null && checkpoint.TablesToIgnore.Any())
                 {
@@ -272,50 +272,28 @@ where 1=1";
 
             public string BuildRelationshipCommandText(Checkpoint checkpoint)
             {
-                //string commandText = @"SELECT DISTINCT
-                //                          PK.CONSTRAINT_SCHEMA AS PK_SCHEMA_NAME,
-                //                          PK.CONSTRAINT_NAME AS PK_NAME,
-                //                          FK.CONSTRAINT_SCHEMA AS FK_SCHEMA_NAME,
-                //                          FK.CONSTRAINT_NAME AS FK_NAME
-                //                       FROM
-                //                          INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS PK
-                //                              INNER JOIN
-                //                          INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS TC ON PK.CONSTRAINT_SCHEMA = TC.CONSTRAINT_SCHEMA
-                //                              AND PK.CONSTRAINT_NAME = TC.CONSTRAINT_NAME
-                //                              INNER JOIN
-                //                          INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS FK ON PK.TABLE_SCHEMA = FK.REFERENCED_TABLE_SCHEMA
-                //                              AND PK.TABLE_NAME = FK.REFERENCED_TABLE_NAME
-                //                       WHERE
-                //                          TC.CONSTRAINT_TYPE = 'PRIMARY KEY'
-                //                              AND PK.TABLE_SCHEMA NOT IN ('mysql' , 'performance_schema');";
-
-                var commandText = @"SELECT CONSTRAINT_SCHEMA, 
-                                              TABLE_NAME, 
-                                              UNIQUE_CONSTRAINT_SCHEMA, 
-                                              REFERENCED_TABLE_NAME 
-                                       FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS";
+                var commandText = @"
+SELECT CONSTRAINT_SCHEMA, 
+    TABLE_NAME, 
+    UNIQUE_CONSTRAINT_SCHEMA, 
+    REFERENCED_TABLE_NAME 
+FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS";
 
                 var whereText = new List<string>();
 
                 if (checkpoint.TablesToIgnore != null && checkpoint.TablesToIgnore.Any())
                 {
                     var args = string.Join(",", checkpoint.TablesToIgnore.Select(t => $"'{t}'"));
-
-                    //commandText += " AND PK.CONSTRAINT_NAME NOT IN (" + args + ")";
                     whereText.Add("TABLE_NAME NOT IN (" + args + ")");
                 }
                 if (checkpoint.SchemasToExclude != null && checkpoint.SchemasToExclude.Any())
                 {
                     var args = string.Join(",", checkpoint.SchemasToExclude.Select(t => $"'{t}'"));
-
-                    //commandText += " PK.CONSTRAINT_SCHEMA NOT IN (" + args + ")";
                     whereText.Add("CONSTRAINT_SCHEMA NOT IN (" + args + ")");
                 }
                 else if (checkpoint.SchemasToInclude != null && checkpoint.SchemasToInclude.Any())
                 {
                     var args = string.Join(",", checkpoint.SchemasToInclude.Select(t => $"'{t}'"));
-
-                    //commandText += " AND PK.CONSTRAINT_SCHEMA IN (" + args + ")";
                     whereText.Add("CONSTRAINT_SCHEMA IN (" + args + ")");
                 }
 
@@ -330,7 +308,7 @@ where 1=1";
 
                 foreach (var tableName in tablesToDelete)
                 {
-                    builder.Append($"DELETE FROM {tableName};\r\n");
+                    builder.Append($"DELETE FROM {tableName};{System.Environment.NewLine}");
                 }
                 return builder.ToString();
             }

--- a/Respawn/DbAdapter.cs
+++ b/Respawn/DbAdapter.cs
@@ -6,6 +6,7 @@
 
     public interface IDbAdapter
     {
+        char QuoteCharacter { get; }
         string BuildTableCommandText(Checkpoint checkpoint);
         string BuildRelationshipCommandText(Checkpoint checkpoint);
         string BuildDeleteCommandText(IEnumerable<string> tablesToDelete);
@@ -16,9 +17,12 @@
         public static readonly IDbAdapter SqlServer = new SqlServerDbAdapter();
         public static readonly IDbAdapter Postgres = new PostgresDbAdapter();
         public static readonly IDbAdapter SqlServerCe = new SqlServerCeDbAdapter();
+        public static readonly IDbAdapter MySql = new MySqlAdapter();
 
         private class SqlServerDbAdapter : IDbAdapter
         {
+            public char QuoteCharacter => '"';
+
             public string BuildTableCommandText(Checkpoint checkpoint)
             {
                 string commandText = @"
@@ -99,6 +103,8 @@ where 1=1";
 
         private class PostgresDbAdapter : IDbAdapter
         {
+            public char QuoteCharacter => '"';
+
             public string BuildTableCommandText(Checkpoint checkpoint)
             {
                 string commandText = @"
@@ -174,6 +180,8 @@ where 1=1";
 
         private class SqlServerCeDbAdapter : IDbAdapter
         {
+            public char QuoteCharacter => '"';
+
             public string BuildTableCommandText(Checkpoint checkpoint)
             {
                 string commandText = @"SELECT table_schema, table_name FROM information_schema.tables AS t WHERE TABLE_TYPE <> N'SYSTEM TABLE'";
@@ -221,6 +229,108 @@ where 1=1";
                 foreach (var tableName in tablesToDelete)
                 {
                     builder.Append($"delete from {tableName};\r\n");
+                }
+                return builder.ToString();
+            }
+        }
+
+        private class MySqlAdapter : IDbAdapter
+        {
+            public char QuoteCharacter => '`';
+
+            public string BuildTableCommandText(Checkpoint checkpoint)
+            {
+                string commandText = @"SELECT 
+                                        t.TABLE_SCHEMA, t.TABLE_NAME
+                                       FROM
+                                        information_schema.tables AS t
+                                       WHERE
+                                        table_type = 'BASE TABLE'
+                                       AND TABLE_SCHEMA NOT IN ('mysql' , 'performance_schema')";
+
+                if (checkpoint.TablesToIgnore != null && checkpoint.TablesToIgnore.Any())
+                {
+                    var args = string.Join(",", checkpoint.TablesToIgnore.Select(t => $"'{t}'"));
+
+                    commandText += " AND t.TABLE_NAME NOT IN (" + args + ")";
+                }
+                if (checkpoint.SchemasToExclude != null && checkpoint.SchemasToExclude.Any())
+                {
+                    var args = string.Join(",", checkpoint.SchemasToExclude.Select(t => $"'{t}'"));
+
+                    commandText += " AND t.TABLE_SCHEMA NOT IN (" + args + ")";
+                }
+                else if (checkpoint.SchemasToInclude != null && checkpoint.SchemasToInclude.Any())
+                {
+                    var args = string.Join(",", checkpoint.SchemasToInclude.Select(t => $"'{t}'"));
+
+                    commandText += " AND t.TABLE_SCHEMA IN (" + args + ")";
+                }
+
+                return commandText;
+            }
+
+            public string BuildRelationshipCommandText(Checkpoint checkpoint)
+            {
+                //string commandText = @"SELECT DISTINCT
+                //                          PK.CONSTRAINT_SCHEMA AS PK_SCHEMA_NAME,
+                //                          PK.CONSTRAINT_NAME AS PK_NAME,
+                //                          FK.CONSTRAINT_SCHEMA AS FK_SCHEMA_NAME,
+                //                          FK.CONSTRAINT_NAME AS FK_NAME
+                //                       FROM
+                //                          INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS PK
+                //                              INNER JOIN
+                //                          INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS TC ON PK.CONSTRAINT_SCHEMA = TC.CONSTRAINT_SCHEMA
+                //                              AND PK.CONSTRAINT_NAME = TC.CONSTRAINT_NAME
+                //                              INNER JOIN
+                //                          INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS FK ON PK.TABLE_SCHEMA = FK.REFERENCED_TABLE_SCHEMA
+                //                              AND PK.TABLE_NAME = FK.REFERENCED_TABLE_NAME
+                //                       WHERE
+                //                          TC.CONSTRAINT_TYPE = 'PRIMARY KEY'
+                //                              AND PK.TABLE_SCHEMA NOT IN ('mysql' , 'performance_schema');";
+
+                var commandText = @"SELECT CONSTRAINT_SCHEMA, 
+                                              TABLE_NAME, 
+                                              UNIQUE_CONSTRAINT_SCHEMA, 
+                                              REFERENCED_TABLE_NAME 
+                                       FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS";
+
+                var whereText = new List<string>();
+
+                if (checkpoint.TablesToIgnore != null && checkpoint.TablesToIgnore.Any())
+                {
+                    var args = string.Join(",", checkpoint.TablesToIgnore.Select(t => $"'{t}'"));
+
+                    //commandText += " AND PK.CONSTRAINT_NAME NOT IN (" + args + ")";
+                    whereText.Add("TABLE_NAME NOT IN (" + args + ")");
+                }
+                if (checkpoint.SchemasToExclude != null && checkpoint.SchemasToExclude.Any())
+                {
+                    var args = string.Join(",", checkpoint.SchemasToExclude.Select(t => $"'{t}'"));
+
+                    //commandText += " PK.CONSTRAINT_SCHEMA NOT IN (" + args + ")";
+                    whereText.Add("CONSTRAINT_SCHEMA NOT IN (" + args + ")");
+                }
+                else if (checkpoint.SchemasToInclude != null && checkpoint.SchemasToInclude.Any())
+                {
+                    var args = string.Join(",", checkpoint.SchemasToInclude.Select(t => $"'{t}'"));
+
+                    //commandText += " AND PK.CONSTRAINT_SCHEMA IN (" + args + ")";
+                    whereText.Add("CONSTRAINT_SCHEMA IN (" + args + ")");
+                }
+
+                if (whereText.Any())
+                    commandText += $" WHERE {string.Join(" AND ", whereText.ToArray())}";
+                return commandText;
+            }
+
+            public string BuildDeleteCommandText(IEnumerable<string> tablesToDelete)
+            {
+                var builder = new StringBuilder();
+
+                foreach (var tableName in tablesToDelete)
+                {
+                    builder.Append($"DELETE FROM {tableName};\r\n");
                 }
                 return builder.ToString();
             }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,7 @@ image: Visual Studio 2017
 services:
   - postgresql
   - mssql2016
+  - mysql
 nuget:
   disable_publish_on_pr: true
 build_script:


### PR DESCRIPTION
We are working with Amazon AWS Aurora in our project which is MySQL compatible, so we need to use
MySql to provide a local equivalent.  Respawn looked ideal for our
tests but needed MySql support, so I added it, hopefully it's good enough to be included?

Here's what I did:
- Added a MySqlAdapter implementation of IDbAdapter to DbAdapter.cs.
- Added MySqlTests with the same tests as the other adapters, these
  pass locally against the latest dockerised version of latest
  MySql 5.7.
- As MySql quotes around tables use ` not " I needed to introduce
  the concept of "QuoteCharacter" in each adapter, this is set to
  " in all adapters except for MySqlAdapter.  Updated the
  GetRelationships and GetTables strings to use the quote character when building strings.
- Updated appveyor config to add mysql to service (to support mysql
  tests).
- Added appveyor compatible connection string to MySqlTests to support
   tests in CI.
- Added mysql service to appveyor.yml to start mysql during build

_I tested the changes against Sql Server and MySql locally (I didn't have Postgres to hand) this should provide coverage of the MySqlAdapter and the very minor change to Checkpoint.cs but the changes to support your CI process seem to have worked looking at the build below._