### PR TITLE
Use xUnit test discoverer to skip Oracle tests on AppVeyor

### DIFF
--- a/Respawn.DatabaseTests/OracleTests.cs
+++ b/Respawn.DatabaseTests/OracleTests.cs
@@ -42,7 +42,7 @@ namespace Respawn.DatabaseTests
             _database = new Database(_connection, DatabaseType.OracleManaged);
         }
 
-        [Fact]
+        [SkipOnAppVeyor]
         public async Task ShouldDeleteData()
         {
             await _database.ExecuteAsync("create table \"foo\" (value int)");
@@ -72,7 +72,7 @@ namespace Respawn.DatabaseTests
             (await _database.ExecuteScalarAsync<int>("SELECT COUNT(1) FROM \"foo\"")).ShouldBe(0);
         }
 
-        [Fact]
+        [SkipOnAppVeyor]
         public async Task ShouldDeleteMultipleTables()
         {
             await _database.ExecuteAsync("create table \"foo\" (value int)");
@@ -95,7 +95,7 @@ namespace Respawn.DatabaseTests
             (await _database.ExecuteScalarAsync<int>("SELECT COUNT(1) FROM \"bar\"")).ShouldBe(0);
         }
 
-        [Fact]
+        [SkipOnAppVeyor]
         public async Task ShouldHandleRelationships()
         {
             _database.Execute("create table \"foo\" (value int, primary key (value))");
@@ -129,7 +129,7 @@ namespace Respawn.DatabaseTests
             _database.ExecuteScalar<int>("SELECT COUNT(1) FROM \"baz\"").ShouldBe(0);
         }
 
-        [Fact]
+        [SkipOnAppVeyor]
         public async Task ShouldHandleComplexCycles()
         {
             _database.Execute("create table \"a\" (\"id\" int primary key, \"b_id\" int NULL)");
@@ -186,7 +186,7 @@ namespace Respawn.DatabaseTests
             _database.ExecuteScalar<int>("SELECT COUNT(1) FROM \"f\"").ShouldBe(0);
         }
 
-        [Fact]
+        [SkipOnAppVeyor]
         public async Task ShouldHandleCircularRelationships()
         {
             _database.Execute("create table \"parent\" (id int primary key, childid int NULL)");
@@ -225,7 +225,7 @@ namespace Respawn.DatabaseTests
             _database.ExecuteScalar<int>("SELECT COUNT(1) FROM \"child\"").ShouldBe(0);
         }
 
-        [Fact]
+        [SkipOnAppVeyor]
         public async Task ShouldIgnoreTables()
         {
             await _database.ExecuteAsync("create table \"foo\" (value int)");
@@ -249,7 +249,7 @@ namespace Respawn.DatabaseTests
             (await _database.ExecuteScalarAsync<int>("SELECT COUNT(1) FROM \"bar\"")).ShouldBe(0);
         }
 
-        [Fact]
+        [SkipOnAppVeyor]
         public async Task ShouldExcludeSchemas()
         {
             var userA = Guid.NewGuid().ToString().Substring(0, 8);
@@ -288,7 +288,7 @@ namespace Respawn.DatabaseTests
             await DropUser(userB);
         }
 
-        [Fact]
+        [SkipOnAppVeyor]
         public async Task ShouldIncludeSchemas()
         {
             var userA = Guid.NewGuid().ToString().Substring(0, 8);

--- a/Respawn.DatabaseTests/OracleTests.cs
+++ b/Respawn.DatabaseTests/OracleTests.cs
@@ -16,7 +16,6 @@ namespace Respawn.DatabaseTests
         private OracleConnection _connection;
         private Database _database;
         private string _createdUser;
-        private bool _skipTests;
 
         public class foo
         {
@@ -30,14 +29,10 @@ namespace Respawn.DatabaseTests
         public OracleTests(ITestOutputHelper output)
         {
             _output = output;
-            _skipTests = Environment.GetEnvironmentVariable("Appveyor")?.ToUpperInvariant() == "TRUE";
         }
 
         public async Task InitializeAsync()
         {
-            if (_skipTests)
-                return;
-
             _createdUser = Guid.NewGuid().ToString().Substring(0, 8);
             await CreateUser(_createdUser);
 
@@ -50,9 +45,6 @@ namespace Respawn.DatabaseTests
         [Fact]
         public async Task ShouldDeleteData()
         {
-            if (_skipTests)
-                return;
-
             await _database.ExecuteAsync("create table \"foo\" (value int)");
 
             for (int i = 0; i < 100; i++)
@@ -83,9 +75,6 @@ namespace Respawn.DatabaseTests
         [Fact]
         public async Task ShouldDeleteMultipleTables()
         {
-            if (_skipTests)
-                return;
-
             await _database.ExecuteAsync("create table \"foo\" (value int)");
             await _database.ExecuteAsync("create table \"bar\" (value int)");
 
@@ -109,9 +98,6 @@ namespace Respawn.DatabaseTests
         [Fact]
         public async Task ShouldHandleRelationships()
         {
-            if (_skipTests)
-                return;
-
             _database.Execute("create table \"foo\" (value int, primary key (value))");
             _database.Execute("create table \"baz\" (value int, foovalue int, constraint FK_Foo foreign key (foovalue) references \"foo\" (value))");
 
@@ -146,9 +132,6 @@ namespace Respawn.DatabaseTests
         [Fact]
         public async Task ShouldHandleComplexCycles()
         {
-            if (_skipTests)
-                return;
-
             _database.Execute("create table \"a\" (\"id\" int primary key, \"b_id\" int NULL)");
             _database.Execute("create table \"b\" (\"id\" int primary key, \"a_id\" int NULL, \"c_id\" int NULL, \"d_id\" int NULL)");
             _database.Execute("create table \"c\" (\"id\" int primary key, \"d_id\" int NULL)");
@@ -206,9 +189,6 @@ namespace Respawn.DatabaseTests
         [Fact]
         public async Task ShouldHandleCircularRelationships()
         {
-            if (_skipTests)
-                return;
-
             _database.Execute("create table \"parent\" (id int primary key, childid int NULL)");
             _database.Execute("create table \"child\" (id int primary key, parentid int NULL)");
             _database.Execute("alter table \"parent\" add constraint FK_Child foreign key (ChildId) references \"child\" (Id)");
@@ -248,9 +228,6 @@ namespace Respawn.DatabaseTests
         [Fact]
         public async Task ShouldIgnoreTables()
         {
-            if (_skipTests)
-                return;
-
             await _database.ExecuteAsync("create table \"foo\" (value int)");
             await _database.ExecuteAsync("create table \"bar\" (value int)");
 
@@ -275,9 +252,6 @@ namespace Respawn.DatabaseTests
         [Fact]
         public async Task ShouldExcludeSchemas()
         {
-            if (_skipTests)
-                return;
-
             var userA = Guid.NewGuid().ToString().Substring(0, 8);
             var userB = Guid.NewGuid().ToString().Substring(0, 8);
             await CreateUser(userA);
@@ -317,9 +291,6 @@ namespace Respawn.DatabaseTests
         [Fact]
         public async Task ShouldIncludeSchemas()
         {
-            if (_skipTests)
-                return;
-
             var userA = Guid.NewGuid().ToString().Substring(0, 8);
             var userB = Guid.NewGuid().ToString().Substring(0, 8);
             await CreateUser(userA);
@@ -396,9 +367,6 @@ namespace Respawn.DatabaseTests
 
         public async Task DisposeAsync()
         {
-            if (_skipTests)
-                return;
-         
             // Clean up our mess before leaving
             await DropUser(_createdUser);
 

--- a/Respawn.DatabaseTests/SkipOnAppVeyorAttribute.cs
+++ b/Respawn.DatabaseTests/SkipOnAppVeyorAttribute.cs
@@ -1,0 +1,34 @@
+﻿namespace Respawn.DatabaseTests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Xunit;
+    using Xunit.Abstractions;
+    using Xunit.Sdk;
+
+    public class SkipOnAppVeyorTestDiscoverer : IXunitTestCaseDiscoverer
+    {
+        private readonly IMessageSink _diagnosticMessageSink;
+
+        public SkipOnAppVeyorTestDiscoverer(IMessageSink diagnosticMessageSink)
+        {
+            _diagnosticMessageSink = diagnosticMessageSink;
+        }
+
+        public IEnumerable<IXunitTestCase> Discover(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo factAttribute)
+        {
+            if (Environment.GetEnvironmentVariable("Appveyor")?.ToUpperInvariant() == "TRUE")
+            {
+                return Enumerable.Empty<IXunitTestCase>();
+            }
+
+            return new[] { new XunitTestCase(_diagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), testMethod) };
+        }
+    }
+
+    [XunitTestCaseDiscoverer("Respawn.DatabaseTests.SkipOnAppVeyorTestDiscoverer", "Respawn.DatabaseTests")]
+    public class SkipOnAppVeyorAttribute : FactAttribute
+    {
+    }
+}


### PR DESCRIPTION
_Disclaimer_: there's not a lot of value in that PR.

I just thought it was a good candidate for a custom xUnit test discoverer and I decided to give it a go given I had never implemented one before.

Feel free to ignore.