### PR TITLE
Deleting data from temporal tables

### DIFF
--- a/Respawn.DatabaseTests/SqlServerTests.cs
+++ b/Respawn.DatabaseTests/SqlServerTests.cs
@@ -358,6 +358,7 @@ namespace Respawn.DatabaseTests
             _database.Execute("UPDATE Foo SET Value = 2 Where Value = 1");
 
             var checkpoint = new Checkpoint();
+            checkpoint.CheckTemporalTables = true;
             await checkpoint.Reset(_connection);
 
             _database.ExecuteScalar<int>("SELECT COUNT(1) FROM FooHistory").ShouldBe(0);
@@ -380,6 +381,7 @@ namespace Respawn.DatabaseTests
             _database.Execute("UPDATE Foo SET Value = 2 Where Value = 1");
 
             var checkpoint = new Checkpoint();
+            checkpoint.CheckTemporalTables = true;
             await checkpoint.Reset(_connection);
 
             var sql = @"
@@ -407,6 +409,7 @@ WHERE t1.object_id = (SELECT history_table_id FROM sys.tables t2 WHERE t2.name =
             _database.Execute("UPDATE Foo SET Value = 2 Where Value = 1");
 
             var checkpoint = new Checkpoint();
+            checkpoint.CheckTemporalTables = true;
             await checkpoint.Reset(_connection);
 
             var sql = @"

--- a/Respawn/Checkpoint.cs
+++ b/Respawn/Checkpoint.cs
@@ -13,12 +13,13 @@ namespace Respawn
     public class Checkpoint
     {
         private GraphBuilder _graphBuilder;
-        private IList<TemporalTable> _temporalTables;
+        private IList<TemporalTable> _temporalTables = new List<TemporalTable>();
 
         public string[] TablesToIgnore { get; set; } = new string[0];
         public string[] SchemasToInclude { get; set; } = new string[0];
         public string[] SchemasToExclude { get; set; } = new string[0];
         public string DeleteSql { get; private set; }
+        public bool CheckTemporalTables { get; set; } = false;
         internal string DatabaseName { get; private set; }
         public IDbAdapter DbAdapter { get; set; } = Respawn.DbAdapter.SqlServer;
 
@@ -91,7 +92,10 @@ namespace Respawn
         {
             var allTables = await GetAllTables(connection);
 
-            _temporalTables = await GetAllTemporalTables(connection);
+            if(CheckTemporalTables)
+            {
+                _temporalTables = await GetAllTemporalTables(connection);
+            }
 
             var allRelationships = await GetRelationships(connection);
 

--- a/Respawn/Checkpoint.cs
+++ b/Respawn/Checkpoint.cs
@@ -45,7 +45,7 @@ namespace Respawn
                 await BuildDeleteTables(connection);
             }
 
-            if (_temporalTables.Count() > 0)
+            if (_temporalTables.Any())
             {
                 var turnOffVersioningCommandText = DbAdapter.BuildTurnOffSystemVersioningCommandText(_temporalTables);
                 await ExecuteAlterSystemVersioningAsync(connection, turnOffVersioningCommandText);
@@ -53,7 +53,7 @@ namespace Respawn
 
             await ExecuteDeleteSqlAsync(connection);
 
-            if (_temporalTables.Count() > 0)
+            if (_temporalTables.Any())
             {
                 var turnOnVersioningCommandText = DbAdapter.BuildTurnOnSystemVersioningCommandText(_temporalTables);
                 await ExecuteAlterSystemVersioningAsync(connection, turnOnVersioningCommandText);

--- a/Respawn/Checkpoint.cs
+++ b/Respawn/Checkpoint.cs
@@ -4,185 +4,199 @@ using Respawn.Graph;
 
 namespace Respawn
 {
-    using System.Collections.Generic;
-    using System.Data.Common;
-    using System.Data.SqlClient;
-    using System.Linq;
-    using System.Threading.Tasks;
+	using System;
+	using System.Collections.Generic;
+	using System.Data.Common;
+	using System.Data.SqlClient;
+	using System.Linq;
+	using System.Threading.Tasks;
 
-    public class Checkpoint
-    {
-        private GraphBuilder _graphBuilder;
-        private IList<TemporalTable> _temporalTables = new List<TemporalTable>();
+	public class Checkpoint
+	{
+		private GraphBuilder _graphBuilder;
+		private IList<TemporalTable> _temporalTables = new List<TemporalTable>();
 
-        public string[] TablesToIgnore { get; set; } = new string[0];
-        public string[] SchemasToInclude { get; set; } = new string[0];
-        public string[] SchemasToExclude { get; set; } = new string[0];
-        public string DeleteSql { get; private set; }
-        public string ReseedSql { get; private set; }
-        public bool CheckTemporalTables { get; set; } = false;
-        internal string DatabaseName { get; private set; }
-        public bool WithReseed { get; set; } = false;
-        public IDbAdapter DbAdapter { get; set; } = Respawn.DbAdapter.SqlServer;
+		public string[] TablesToIgnore { get; set; } = new string[0];
+		public string[] SchemasToInclude { get; set; } = new string[0];
+		public string[] SchemasToExclude { get; set; } = new string[0];
+		public string DeleteSql { get; private set; }
+		public string ReseedSql { get; private set; }
+		public bool CheckTemporalTables { get; set; } = false;
+		internal string DatabaseName { get; private set; }
+		public bool WithReseed { get; set; } = false;
+		public IDbAdapter DbAdapter { get; set; } = Respawn.DbAdapter.SqlServer;
 
-        public int? CommandTimeout { get; set; }
+		public int? CommandTimeout { get; set; }
 
-        public virtual async Task Reset(string nameOrConnectionString)
-        {
-            using (var connection = new SqlConnection(nameOrConnectionString))
-            {
-                await connection.OpenAsync();
+		public virtual async Task Reset(string nameOrConnectionString)
+		{
+			using (var connection = new SqlConnection(nameOrConnectionString))
+			{
+				await connection.OpenAsync();
 
-                await Reset(connection);
-            }
-        }
+				await Reset(connection);
+			}
+		}
 
-        public virtual async Task Reset(DbConnection connection)
-        {
-            if (string.IsNullOrWhiteSpace(DeleteSql))
-            {
-                DatabaseName = connection.Database;
-                await BuildDeleteTables(connection);
-            }
+		public virtual async Task Reset(DbConnection connection)
+		{
+			if (string.IsNullOrWhiteSpace(DeleteSql))
+			{
+				DatabaseName = connection.Database;
+				await BuildDeleteTables(connection);
+			}
 
-            if (_temporalTables.Any())
-            {
-                var turnOffVersioningCommandText = DbAdapter.BuildTurnOffSystemVersioningCommandText(_temporalTables);
-                await ExecuteAlterSystemVersioningAsync(connection, turnOffVersioningCommandText);
-            }
+			if (_temporalTables.Any())
+			{
+				var turnOffVersioningCommandText = DbAdapter.BuildTurnOffSystemVersioningCommandText(_temporalTables);
+				await ExecuteAlterSystemVersioningAsync(connection, turnOffVersioningCommandText);
+			}
 
-            await ExecuteDeleteSqlAsync(connection);
+			await ExecuteDeleteSqlAsync(connection);
 
-            if (_temporalTables.Any())
-            {
-                var turnOnVersioningCommandText = DbAdapter.BuildTurnOnSystemVersioningCommandText(_temporalTables);
-                await ExecuteAlterSystemVersioningAsync(connection, turnOnVersioningCommandText);
-            }
-        }
+			if (_temporalTables.Any())
+			{
+				var turnOnVersioningCommandText = DbAdapter.BuildTurnOnSystemVersioningCommandText(_temporalTables);
+				await ExecuteAlterSystemVersioningAsync(connection, turnOnVersioningCommandText);
+			}
+		}
 
-        private async Task ExecuteAlterSystemVersioningAsync(DbConnection connection, string commandText)
-        {
-            using (var tx = connection.BeginTransaction())
-            using (var cmd = connection.CreateCommand())
-            {
-                cmd.CommandTimeout = CommandTimeout ?? cmd.CommandTimeout;
-                cmd.CommandText = commandText;
-                cmd.Transaction = tx;
+		private async Task ExecuteAlterSystemVersioningAsync(DbConnection connection, string commandText)
+		{
+			using (var tx = connection.BeginTransaction())
+			using (var cmd = connection.CreateCommand())
+			{
+				cmd.CommandTimeout = CommandTimeout ?? cmd.CommandTimeout;
+				cmd.CommandText = commandText;
+				cmd.Transaction = tx;
 
-                await cmd.ExecuteNonQueryAsync();
+				await cmd.ExecuteNonQueryAsync();
 
-                tx.Commit();
-            }
-        }
+				tx.Commit();
+			}
+		}
 
-        private async Task ExecuteDeleteSqlAsync(DbConnection connection)
-        {
-            using (var tx = connection.BeginTransaction())
-            using (var cmd = connection.CreateCommand())
-            {
-                cmd.CommandTimeout = CommandTimeout ?? cmd.CommandTimeout;
-                cmd.CommandText = DeleteSql;
-                cmd.Transaction = tx;
-                await cmd.ExecuteNonQueryAsync();
-                if (ReseedSql != null)
-                {
-                    cmd.CommandText = ReseedSql;
-                    await cmd.ExecuteNonQueryAsync();
-                }
+		private async Task ExecuteDeleteSqlAsync(DbConnection connection)
+		{
+			using (var tx = connection.BeginTransaction())
+			using (var cmd = connection.CreateCommand())
+			{
+				cmd.CommandTimeout = CommandTimeout ?? cmd.CommandTimeout;
+				cmd.CommandText = DeleteSql;
+				cmd.Transaction = tx;
+				await cmd.ExecuteNonQueryAsync();
+				if (ReseedSql != null)
+				{
+					cmd.CommandText = ReseedSql;
+					await cmd.ExecuteNonQueryAsync();
+				}
 
-                tx.Commit();
-            }
-        }
+				tx.Commit();
+			}
+		}
 
-        private async Task BuildDeleteTables(DbConnection connection)
-        {
-            var allTables = await GetAllTables(connection);
+		private async Task BuildDeleteTables(DbConnection connection)
+		{
+			var allTables = await GetAllTables(connection);
 
-            if(CheckTemporalTables)
-            {
-                _temporalTables = await GetAllTemporalTables(connection);
-            }
+			if (CheckTemporalTables && DoesDbSupportsTemporalTables(connection))
+			{
+				_temporalTables = await GetAllTemporalTables(connection);
+			}
 
-            var allRelationships = await GetRelationships(connection);
+			var allRelationships = await GetRelationships(connection);
 
-            _graphBuilder = new GraphBuilder(allTables, allRelationships);
+			_graphBuilder = new GraphBuilder(allTables, allRelationships);
 
-            DeleteSql = DbAdapter.BuildDeleteCommandText(_graphBuilder);
-            if (WithReseed)
-            {
-                ReseedSql = DbAdapter.BuildReseedSql(_graphBuilder.ToDelete);
-            }
-            else
-            {
-                ReseedSql = null;
-            }
-        }
+			DeleteSql = DbAdapter.BuildDeleteCommandText(_graphBuilder);
+			if (WithReseed)
+			{
+				ReseedSql = DbAdapter.BuildReseedSql(_graphBuilder.ToDelete);
+			}
+			else
+			{
+				ReseedSql = null;
+			}
+		}
 
-        private async Task<HashSet<Relationship>> GetRelationships(DbConnection connection)
-        {
-            var rels = new HashSet<Relationship>();
-            var commandText = DbAdapter.BuildRelationshipCommandText(this);
+		private async Task<HashSet<Relationship>> GetRelationships(DbConnection connection)
+		{
+			var rels = new HashSet<Relationship>();
+			var commandText = DbAdapter.BuildRelationshipCommandText(this);
 
-            using (var cmd = connection.CreateCommand())
-            {
-                cmd.CommandText = commandText;
-                using (var reader = await cmd.ExecuteReaderAsync())
-                {
-                    while (await reader.ReadAsync())
-                    {
-                        rels.Add(new Relationship(
-                            reader.IsDBNull(0) ? null : reader.GetString(0),
-                            reader.GetString(1),
-                            reader.IsDBNull(2) ? null : reader.GetString(2), 
-                            reader.GetString(3), 
-                            reader.GetString(4)));
-                    }
-                }
-            }
+			using (var cmd = connection.CreateCommand())
+			{
+				cmd.CommandText = commandText;
+				using (var reader = await cmd.ExecuteReaderAsync())
+				{
+					while (await reader.ReadAsync())
+					{
+						rels.Add(new Relationship(
+							reader.IsDBNull(0) ? null : reader.GetString(0),
+							reader.GetString(1),
+							reader.IsDBNull(2) ? null : reader.GetString(2),
+							reader.GetString(3),
+							reader.GetString(4)));
+					}
+				}
+			}
 
-            return rels;
-        }
+			return rels;
+		}
 
-        private async Task<HashSet<Table>> GetAllTables(DbConnection connection)
-        {
-            var tables = new HashSet<Table>();
+		private async Task<HashSet<Table>> GetAllTables(DbConnection connection)
+		{
+			var tables = new HashSet<Table>();
 
-            string commandText = DbAdapter.BuildTableCommandText(this);
+			string commandText = DbAdapter.BuildTableCommandText(this);
 
-            using (var cmd = connection.CreateCommand())
-            {
-                cmd.CommandText = commandText;
-                using (var reader = await cmd.ExecuteReaderAsync())
-                {
-                    while (await reader.ReadAsync())
-                    {
-                        tables.Add(new Table(reader.IsDBNull(0) ? null : reader.GetString(0), reader.GetString(1)));
-                    }
-                }
-            }
+			using (var cmd = connection.CreateCommand())
+			{
+				cmd.CommandText = commandText;
+				using (var reader = await cmd.ExecuteReaderAsync())
+				{
+					while (await reader.ReadAsync())
+					{
+						tables.Add(new Table(reader.IsDBNull(0) ? null : reader.GetString(0), reader.GetString(1)));
+					}
+				}
+			}
 
-            return tables;
-        }
+			return tables;
+		}
 
-        private async Task<IList<TemporalTable>> GetAllTemporalTables(DbConnection connection)
-        {
-            var tables = new List<TemporalTable>();
+		private async Task<IList<TemporalTable>> GetAllTemporalTables(DbConnection connection)
+		{
+			var tables = new List<TemporalTable>();
 
-            string commandText = DbAdapter.BuildTemporalTableCommandText(this);
+			string commandText = DbAdapter.BuildTemporalTableCommandText(this);
 
-            using (var cmd = connection.CreateCommand())
-            {
-                cmd.CommandText = commandText;
-                using (var reader = await cmd.ExecuteReaderAsync())
-                {
-                    while (await reader.ReadAsync())
-                    {
-                        tables.Add(new TemporalTable(reader.IsDBNull(0) ? null : reader.GetString(0), reader.GetString(1), reader.GetString(2)));
-                    }
-                }
-            }
+			using (var cmd = connection.CreateCommand())
+			{
+				cmd.CommandText = commandText;
+				using (var reader = await cmd.ExecuteReaderAsync())
+				{
+					while (await reader.ReadAsync())
+					{
+						tables.Add(new TemporalTable(reader.IsDBNull(0) ? null : reader.GetString(0), reader.GetString(1), reader.GetString(2)));
+					}
+				}
+			}
 
-            return tables;
-        }
-    }
+			return tables;
+		}
+
+		private bool DoesDbSupportsTemporalTables(DbConnection connection)
+		{
+			if (DbAdapter.GetType() == Respawn.DbAdapter.SqlServer.GetType())
+			{
+				const int SqlServer2016MajorBuildVersion = 13;
+				string serverVersion = connection.ServerVersion;
+				string[] serverVersionDetails = serverVersion.Split(new string[] { "." }, StringSplitOptions.None);
+				int versionNumber = int.Parse(serverVersionDetails[0]);
+				return versionNumber >= SqlServer2016MajorBuildVersion;
+			}
+			return false;
+		}
+	}
 }

--- a/Respawn/Checkpoint.cs
+++ b/Respawn/Checkpoint.cs
@@ -13,6 +13,7 @@ namespace Respawn
     public class Checkpoint
     {
         private GraphBuilder _graphBuilder;
+        private IList<TemporalTable> _temporalTables;
 
         public string[] TablesToIgnore { get; set; } = new string[0];
         public string[] SchemasToInclude { get; set; } = new string[0];
@@ -41,7 +42,34 @@ namespace Respawn
                 await BuildDeleteTables(connection);
             }
 
+            if (_temporalTables.Count() > 0)
+            {
+                var turnOffVersioningCommandText = DbAdapter.BuildTurnOffSystemVersioningCommandText(_temporalTables);
+                await ExecuteAlterSystemVersioningAsync(connection, turnOffVersioningCommandText);
+            }
+
             await ExecuteDeleteSqlAsync(connection);
+
+            if (_temporalTables.Count() > 0)
+            {
+                var turnOnVersioningCommandText = DbAdapter.BuildTurnOnSystemVersioningCommandText(_temporalTables);
+                await ExecuteAlterSystemVersioningAsync(connection, turnOnVersioningCommandText);
+            }
+        }
+
+        private async Task ExecuteAlterSystemVersioningAsync(DbConnection connection, string commandText)
+        {
+            using (var tx = connection.BeginTransaction())
+            using (var cmd = connection.CreateCommand())
+            {
+                cmd.CommandTimeout = CommandTimeout ?? cmd.CommandTimeout;
+                cmd.CommandText = commandText;
+                cmd.Transaction = tx;
+
+                await cmd.ExecuteNonQueryAsync();
+
+                tx.Commit();
+            }
         }
 
         private async Task ExecuteDeleteSqlAsync(DbConnection connection)
@@ -62,6 +90,8 @@ namespace Respawn
         private async Task BuildDeleteTables(DbConnection connection)
         {
             var allTables = await GetAllTables(connection);
+
+            _temporalTables = await GetAllTemporalTables(connection);
 
             var allRelationships = await GetRelationships(connection);
 
@@ -109,6 +139,27 @@ namespace Respawn
                     while (await reader.ReadAsync())
                     {
                         tables.Add(new Table(reader.IsDBNull(0) ? null : reader.GetString(0), reader.GetString(1)));
+                    }
+                }
+            }
+
+            return tables;
+        }
+
+        private async Task<IList<TemporalTable>> GetAllTemporalTables(DbConnection connection)
+        {
+            var tables = new List<TemporalTable>();
+
+            string commandText = DbAdapter.BuildTemporalTableCommandText(this);
+
+            using (var cmd = connection.CreateCommand())
+            {
+                cmd.CommandText = commandText;
+                using (var reader = await cmd.ExecuteReaderAsync())
+                {
+                    while (await reader.ReadAsync())
+                    {
+                        tables.Add(new TemporalTable(reader.IsDBNull(0) ? null : reader.GetString(0), reader.GetString(1), reader.GetString(2)));
                     }
                 }
             }

--- a/Respawn/Graph/TemporalTable.cs
+++ b/Respawn/Graph/TemporalTable.cs
@@ -1,0 +1,16 @@
+﻿namespace Respawn.Graph
+{
+    public class TemporalTable
+    {
+        public TemporalTable(string schema, string name, string historyTableName)
+        {
+            Schema = schema;
+            Name = name;
+            HistoryTableName = historyTableName;
+        }
+
+        public string Schema { get; }
+        public string Name { get; }
+        public string HistoryTableName { get; }
+    }
+}


### PR DESCRIPTION
Fixes #33 

To delete data from temporal tables, system versioning needs to be turned off on them. After deleting the data, system versioning with original name of the history table is re-enabled. I have added a class for `TemporalTable` but I guess I can use `Table` class itself? Please let me know.

I have added code only for Sql Server. Never worked with other databases. 