### PR TITLE
Add posiblity to specifiy which tables to include

### DIFF
--- a/Respawn.DatabaseTests/MySqlTests.cs
+++ b/Respawn.DatabaseTests/MySqlTests.cs
@@ -33,7 +33,7 @@ namespace Respawn.DatabaseTests
             var connString =
                 isAppVeyor
                     ? @"Server=127.0.0.1; port = 3306; User Id = root; Password = Password12!"
-                    : @"Server=192.168.99.100; port = 8082; User Id = root; Password = testytest";
+                    : @"Server=127.0.0.1; port = 8082; User Id = root; Password = testytest";
 
             _connection = new MySqlConnection(connString);
             _connection.Open();

--- a/Respawn.DatabaseTests/PostgresTests.cs
+++ b/Respawn.DatabaseTests/PostgresTests.cs
@@ -20,8 +20,8 @@ namespace Respawn.DatabaseTests
 
         public async Task InitializeAsync()
         {
-            var rootConnString = "Server=192.168.99.100;Port=8081;User ID=docker;Password=Password12!;database=postgres";
-            var dbConnString = "Server=192.168.99.100;Port=8081;User ID=docker;Password=Password12!;database={0}";
+            var rootConnString = "Server=127.0.0.1;Port=8081;User ID=docker;Password=Password12!;database=postgres";
+            var dbConnString = "Server=127.0.0.1;Port=8081;User ID=docker;Password=Password12!;database={0}";
             if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("APPVEYOR")))
             {
                 rootConnString = "Server=127.0.0.1;Port=5432;User ID=postgres;Password=Password12!;database=postgres";

--- a/Respawn/Checkpoint.cs
+++ b/Respawn/Checkpoint.cs
@@ -15,6 +15,7 @@ namespace Respawn
         private GraphBuilder _graphBuilder;
 
         public string[] TablesToIgnore { get; set; } = new string[0];
+        public string[] TablesToInclude { get; set; } = new string[0];
         public string[] SchemasToInclude { get; set; } = new string[0];
         public string[] SchemasToExclude { get; set; } = new string[0];
         public string DeleteSql { get; private set; }

--- a/Respawn/DbAdapter.cs
+++ b/Respawn/DbAdapter.cs
@@ -186,6 +186,12 @@ where TABLE_TYPE = 'BASE TABLE'"
 
                     commandText += " AND TABLE_NAME NOT IN (" + args + ")";
                 }
+                if (checkpoint.TablesToInclude.Any())
+                {
+                    var args = string.Join(",", checkpoint.TablesToInclude.Select(t => $"'{t}'"));
+
+                    commandText += " AND TABLE_NAME IN (" + args + ")";
+                }
                 if (checkpoint.SchemasToExclude.Any())
                 {
                     var args = string.Join(",", checkpoint.SchemasToExclude.Select(t => $"'{t}'"));
@@ -216,6 +222,12 @@ where 1=1";
                     var args = string.Join(",", checkpoint.TablesToIgnore.Select(t => $"'{t}'"));
 
                     commandText += " AND tc.TABLE_NAME NOT IN (" + args + ")";
+                }
+                if (checkpoint.TablesToInclude.Any())
+                {
+                    var args = string.Join(",", checkpoint.TablesToIgnore.Select(t => $"'{t}'"));
+
+                    commandText += " AND tc.TABLE_NAME IN (" + args + ")";
                 }
                 if (checkpoint.SchemasToExclude.Any())
                 {
@@ -279,6 +291,12 @@ WHERE
 
                     commandText += " AND t.TABLE_NAME NOT IN (" + args + ")";
                 }
+                if (checkpoint.TablesToInclude != null && checkpoint.TablesToInclude.Any())
+                {
+                    var args = string.Join(",", checkpoint.TablesToInclude.Select(t => $"'{t}'"));
+
+                    commandText += " AND t.TABLE_NAME IN (" + args + ")";
+                }
                 if (checkpoint.SchemasToExclude != null && checkpoint.SchemasToExclude.Any())
                 {
                     var args = string.Join(",", checkpoint.SchemasToExclude.Select(t => $"'{t}'"));
@@ -312,6 +330,11 @@ FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS";
                 {
                     var args = string.Join(",", checkpoint.TablesToIgnore.Select(t => $"'{t}'"));
                     whereText.Add("TABLE_NAME NOT IN (" + args + ")");
+                }
+                if (checkpoint.TablesToInclude != null && checkpoint.TablesToInclude.Any())
+                {
+                    var args = string.Join(",", checkpoint.TablesToInclude.Select(t => $"'{t}'"));
+                    whereText.Add("TABLE_NAME IN (" + args + ")");
                 }
                 if (checkpoint.SchemasToExclude != null && checkpoint.SchemasToExclude.Any())
                 {
@@ -367,6 +390,12 @@ where 1=1 "
 
                     commandText += " AND TABLE_NAME NOT IN (" + args + ")";
                 }
+                if (checkpoint.TablesToInclude.Any())
+                {
+                    var args = string.Join(",", checkpoint.TablesToInclude.Select(table => $"'{table}'").ToArray());
+
+                    commandText += " AND TABLE_NAME IN (" + args + ")";
+                }
                 if (checkpoint.SchemasToExclude.Any())
                 {
                     var args = string.Join(",", checkpoint.SchemasToExclude.Select(schema => $"'{schema}'").ToArray());
@@ -396,6 +425,12 @@ from all_CONSTRAINTS     a
                     var args = string.Join(",", checkpoint.TablesToIgnore.Select(s => $"'{s}'").ToArray());
 
                     commandText += " AND a.TABLE_NAME NOT IN (" + args + ")";
+                }
+                if (checkpoint.TablesToInclude.Any())
+                {
+                    var args = string.Join(",", checkpoint.TablesToInclude.Select(s => $"'{s}'").ToArray());
+
+                    commandText += " AND a.TABLE_NAME IN (" + args + ")";
                 }
                 if (checkpoint.SchemasToExclude.Any())
                 {

--- a/Respawn/DbAdapter.cs
+++ b/Respawn/DbAdapter.cs
@@ -225,7 +225,7 @@ where 1=1";
                 }
                 if (checkpoint.TablesToInclude.Any())
                 {
-                    var args = string.Join(",", checkpoint.TablesToIgnore.Select(t => $"'{t}'"));
+                    var args = string.Join(",", checkpoint.TablesToInclude.Select(t => $"'{t}'"));
 
                     commandText += " AND tc.TABLE_NAME IN (" + args + ")";
                 }

--- a/Respawn/DbAdapter.cs
+++ b/Respawn/DbAdapter.cs
@@ -39,6 +39,12 @@ WHERE 1=1";
 
                     commandText += " AND t.name NOT IN (" + args + ")";
                 }
+                if (checkpoint.TablesToInclude.Any())
+                {
+                    var args = string.Join(",", checkpoint.TablesToInclude.Select(t => $"N'{t}'"));
+
+                    commandText += " AND t.name IN (" + args + ")";
+                }
                 if (checkpoint.SchemasToExclude.Any())
                 {
                     var args = string.Join(",", checkpoint.SchemasToExclude.Select(t => $"N'{t}'"));
@@ -75,6 +81,12 @@ where 1=1";
                     var args = string.Join(",", checkpoint.TablesToIgnore.Select(t => $"N'{t}'"));
 
                     commandText += " AND so_pk.name NOT IN (" + args + ")";
+                }
+                if (checkpoint.TablesToInclude != null && checkpoint.TablesToInclude.Any())
+                {
+                    var args = string.Join(",", checkpoint.TablesToInclude.Select(t => $"N'{t}'"));
+
+                    commandText += " AND so_pk.name IN (" + args + ")";
                 }
                 if (checkpoint.SchemasToExclude != null && checkpoint.SchemasToExclude.Any())
                 {


### PR DESCRIPTION
Similar to the SchemasToInclude functionality I added the possiblity to specify which TablesToInclude.
In our project most database tables are used for configuration and this tables should not be deleted during tests. For us it’s easier to specify which tables to include (20 tables) instead of listing all tables which should be ignored (80 tables).