### PR TITLE
Feature/disable triggers

### DIFF
--- a/Respawn/DbAdapter.cs
+++ b/Respawn/DbAdapter.cs
@@ -209,7 +209,9 @@ where 1=1";
                 }
                 foreach (var table in graph.ToDelete)
                 {
+                    builder.AppendLine($"ALTER TABLE {table.GetFullName(QuoteCharacter)} DISABLE TRIGGER ALL;");
                     builder.AppendLine($"DELETE {table.GetFullName(QuoteCharacter)};");
+                    builder.AppendLine($"ALTER TABLE {table.GetFullName(QuoteCharacter)} ENABLE TRIGGER ALL;");
                 }
                 foreach (var table in graph.CyclicalTableRelationships.Select(rel => rel.ParentTable))
                 {


### PR DESCRIPTION
In some of our legacy databases we have tables with delete triggers that insert into auditing tables. This is causing some issues with using Respawn. 

I've wrapped the delete statement with disable/enable trigger and created a unit test for it.

I thought about adding a flag for this, but wasn't sure if that would be necessary. If customization is necessary in future, maybe the adapters could be made public so one could do something like:
 
```
checkpoint.Adapter = new SqlServerDbAdapter { DisableTriggers = true }; 
```

Not sure why it's messing with the spacing in the other tests.