### PR TITLE
truncate all tables using single statement in postgres

### DIFF
--- a/Respawn/DbAdapter.cs
+++ b/Respawn/DbAdapter.cs
@@ -348,9 +348,10 @@ where 1=1";
                 {
                     builder.AppendLine($"ALTER TABLE {table.GetFullName(QuoteCharacter)} DISABLE TRIGGER ALL;");
                 }
-                foreach (var table in graph.ToDelete)
+                if (graph.ToDelete.Any())
                 {
-                    builder.AppendLine($"truncate table {table.GetFullName(QuoteCharacter)} cascade;");
+                    var allTables = graph.ToDelete.Select(table => table.GetFullName(QuoteCharacter));
+                    builder.AppendLine($"truncate table {string.Join(",", allTables)} cascade;");
                 }
                 foreach (var table in graph.CyclicalTableRelationships.Select(rel => rel.ParentTable))
                 {


### PR DESCRIPTION
I'm using this library in large project to clean part of database current implementation takes ~45 seconds. It's not really viable solution if we want to have a lot of tests. After some inspection I found small change that improves performance. If we create only single truncation statement instead of ~45s we get ~4seconds. These times are for cold run, when graph has to be built, consecutive tests should be even faster.