### PR TITLE
Added support to ignore tables with the same names from different schema

### DIFF
--- a/Respawn/DbAdapter.cs
+++ b/Respawn/DbAdapter.cs
@@ -151,6 +151,7 @@ WHERE 1=1";
                     var args = string.Join(",", checkpoint.TablesToIgnore.Select(t => $"N'{t}'"));
 
                     commandText += " AND t.name NOT IN (" + args + ")";
+                    commandText += " AND (s.name + '.' + t.name) NOT IN (" + args.Replace("[","").Replace("]","") + ")";
                 }
                 if (checkpoint.TablesToInclude.Any())
                 {


### PR DESCRIPTION
We have a case where we have multiple schemas and in some schemas, we have same table names.
I've added support for the SQL Server to check both schema and table names when clearing the data.