### PR TITLE
Exclude internal Postgres schema from delete commands

### DIFF
--- a/Respawn.DatabaseTests/PostgresTests.cs
+++ b/Respawn.DatabaseTests/PostgresTests.cs
@@ -66,8 +66,7 @@ namespace Respawn.DatabaseTests
 
             var checkpoint = new Checkpoint
             {
-                DbAdapter = DbAdapter.Postgres,
-                SchemasToInclude = new [] { "public" }
+                DbAdapter = DbAdapter.Postgres
             };
             await checkpoint.Reset(_connection);
 
@@ -89,7 +88,6 @@ namespace Respawn.DatabaseTests
             var checkpoint = new Checkpoint
             {
                 DbAdapter = DbAdapter.Postgres,
-                SchemasToInclude = new[] { "public" },
                 TablesToIgnore = new[] { "foo" }
             };
             await checkpoint.Reset(_connection);
@@ -113,7 +111,6 @@ namespace Respawn.DatabaseTests
             var checkpoint = new Checkpoint
             {
                 DbAdapter = DbAdapter.Postgres,
-                SchemasToInclude = new[] { "public" },
                 TablesToInclude = new[] { "foo" }
             };
             await checkpoint.Reset(_connection);
@@ -178,8 +175,7 @@ namespace Respawn.DatabaseTests
 
             var checkpoint = new Checkpoint
             {
-                DbAdapter = DbAdapter.Postgres,
-                SchemasToInclude = new[] { "public" }
+                DbAdapter = DbAdapter.Postgres
             };
             try
             {
@@ -211,8 +207,7 @@ namespace Respawn.DatabaseTests
 
             var checkpoint = new Checkpoint
             {
-                DbAdapter = DbAdapter.Postgres,
-                SchemasToInclude = new[] { "public" }
+                DbAdapter = DbAdapter.Postgres
             };
             try
             {
@@ -263,8 +258,7 @@ namespace Respawn.DatabaseTests
 
             var checkpoint = new Checkpoint
             {
-                DbAdapter = DbAdapter.Postgres,
-                SchemasToInclude = new[] { "public" }
+                DbAdapter = DbAdapter.Postgres
             };
             try
             {
@@ -302,7 +296,7 @@ namespace Respawn.DatabaseTests
             var checkpoint = new Checkpoint
             {
                 DbAdapter = DbAdapter.Postgres,
-                SchemasToExclude = new [] { "a", "pg_catalog" }
+                SchemasToExclude = new [] { "a" }
             };
             await checkpoint.Reset(_connection);
 

--- a/Respawn/DbAdapter.cs
+++ b/Respawn/DbAdapter.cs
@@ -323,6 +323,10 @@ WHERE t.temporal_type = 2";
         {
             private const char QuoteCharacter = '"';
 
+            // Postgres has some schemas containing internal schemas that should not be deleted.
+            private const string InformationSchema = "information_schema";
+            private const string PostgresSchemaPrefix = "pg_";
+
             public string BuildTableCommandText(Checkpoint checkpoint)
             {
                 string commandText = @"
@@ -346,14 +350,21 @@ where TABLE_TYPE = 'BASE TABLE'"
                 if (checkpoint.SchemasToExclude.Any())
                 {
                     var args = string.Join(",", checkpoint.SchemasToExclude.Select(t => $"'{t}'"));
+                    args += $", '{InformationSchema}'";
 
                     commandText += " AND TABLE_SCHEMA NOT IN (" + args + ")";
+                    commandText += $" AND TABLE_SCHEMA NOT LIKE '{PostgresSchemaPrefix}%'";
                 }
                 else if (checkpoint.SchemasToInclude.Any())
                 {
                     var args = string.Join(",", checkpoint.SchemasToInclude.Select(t => $"'{t}'"));
 
                     commandText += " AND TABLE_SCHEMA IN (" + args + ")";
+                }
+                else
+                {
+                    commandText += $" AND TABLE_SCHEMA != '{InformationSchema}'";
+                    commandText += $" AND TABLE_SCHEMA NOT LIKE '{PostgresSchemaPrefix}%'";
                 }
 
                 return commandText;


### PR DESCRIPTION
Aside from `information_schema`, Postgres stuffs its internal tables behind a schema always prefixed with `pg_`. This pull request ensures whenever tables are excluded, all sensitive tables mentioned are excluded from deletion.

I updated the unit tests by removing the included `public` schema, which lets the internal table exclusion code path to run.

Fixes #70.