### PR TITLE
Fix / Add support for Azure SQL Temporal Tables

### DIFF
--- a/Respawn/Checkpoint.cs
+++ b/Respawn/Checkpoint.cs
@@ -93,7 +93,7 @@ namespace Respawn
 		{
 			var allTables = await GetAllTables(connection);
 
-			if (CheckTemporalTables && DoesDbSupportsTemporalTables(connection))
+			if (CheckTemporalTables && await DbAdapter.CheckSupportsTemporalTables(connection))
 			{
 				_temporalTables = await GetAllTemporalTables(connection);
 			}
@@ -168,16 +168,16 @@ namespace Respawn
             return tables;
 		}
 
-		private bool DoesDbSupportsTemporalTables(DbConnection connection)
-		{
-            if (! DbAdapter.SupportsTemporalTables) 
-                return false;
+		//private bool DoesDbSupportsTemporalTables(DbConnection connection)
+		//{
+  //          if (! DbAdapter.SupportsTemporalTables) 
+  //              return false;
 
-            const int SqlServer2016MajorBuildVersion = 13;
-            var serverVersion = connection.ServerVersion;
-            var serverVersionDetails = serverVersion.Split(new[] { "." }, StringSplitOptions.None);
-            var versionNumber = int.Parse(serverVersionDetails[0]);
-            return versionNumber >= SqlServer2016MajorBuildVersion;
-        }
+  //          const int SqlServer2016MajorBuildVersion = 13;
+  //          var serverVersion = connection.ServerVersion;
+  //          var serverVersionDetails = serverVersion.Split(new[] { "." }, StringSplitOptions.None);
+  //          var versionNumber = int.Parse(serverVersionDetails[0]);
+  //          return versionNumber >= SqlServer2016MajorBuildVersion;
+  //      }
 	}
 }

--- a/Respawn/IDbAdapter.cs
+++ b/Respawn/IDbAdapter.cs
@@ -1,4 +1,6 @@
 ﻿using System.Collections.Generic;
+using System.Data.Common;
+using System.Threading.Tasks;
 using Respawn.Graph;
 
 namespace Respawn
@@ -12,6 +14,9 @@ namespace Respawn
         string BuildReseedSql(IEnumerable<Table> tablesToDelete);
         string BuildTurnOffSystemVersioningCommandText(IEnumerable<TemporalTable> tablesToTurnOffSystemVersioning);
         string BuildTurnOnSystemVersioningCommandText(IEnumerable<TemporalTable> tablesToTurnOnSystemVersioning);
-        bool SupportsTemporalTables { get; }
+        Task<bool> CheckSupportsTemporalTables(DbConnection connection)
+        {
+            return Task.FromResult(false);
+        }
     }
 }

--- a/Respawn/InformixDbAdapter.cs
+++ b/Respawn/InformixDbAdapter.cs
@@ -1,6 +1,8 @@
 ﻿using System.Collections.Generic;
+using System.Data.Common;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 using Respawn.Graph;
 
 namespace Respawn
@@ -202,7 +204,10 @@ namespace Respawn
         public string BuildTurnOffSystemVersioningCommandText(IEnumerable<TemporalTable> tablesToTurnOffSystemVersioning) => throw new System.NotImplementedException();
 
         public string BuildTurnOnSystemVersioningCommandText(IEnumerable<TemporalTable> tablesToTurnOnSystemVersioning) => throw new System.NotImplementedException();
-
-        public bool SupportsTemporalTables => false;
+        
+        public Task<bool> CheckSupportsTemporalTables(DbConnection connection)
+        {
+            return Task.FromResult(false);
+        }
     }
 }

--- a/Respawn/MySqlAdapter.cs
+++ b/Respawn/MySqlAdapter.cs
@@ -1,6 +1,8 @@
 ﻿using System.Collections.Generic;
+using System.Data.Common;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 using Respawn.Graph;
 
 namespace Respawn
@@ -206,7 +208,10 @@ FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS";
         public string BuildTurnOffSystemVersioningCommandText(IEnumerable<TemporalTable> tablesToTurnOffSystemVersioning) => throw new System.NotImplementedException();
 
         public string BuildTurnOnSystemVersioningCommandText(IEnumerable<TemporalTable> tablesToTurnOnSystemVersioning) => throw new System.NotImplementedException();
-
-        public bool SupportsTemporalTables => false;
+        
+        public Task<bool> CheckSupportsTemporalTables(DbConnection connection)
+        {
+            return Task.FromResult(false);
+        }
     }
 }

--- a/Respawn/OracleDbAdapter.cs
+++ b/Respawn/OracleDbAdapter.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.Generic;
+using System.Data.Common;
 using System.Linq;
+using System.Threading.Tasks;
 using Respawn.Graph;
 
 namespace Respawn
@@ -196,7 +198,10 @@ from all_CONSTRAINTS     a
         public string BuildTurnOffSystemVersioningCommandText(IEnumerable<TemporalTable> tablesToTurnOffSystemVersioning) => throw new System.NotImplementedException();
 
         public string BuildTurnOnSystemVersioningCommandText(IEnumerable<TemporalTable> tablesToTurnOnSystemVersioning) => throw new System.NotImplementedException();
-
-        public bool SupportsTemporalTables => false;
+        
+        public Task<bool> CheckSupportsTemporalTables(DbConnection connection)
+        {
+            return Task.FromResult(false);
+        }
     }
 }

--- a/Respawn/PostgresDbAdapter.cs
+++ b/Respawn/PostgresDbAdapter.cs
@@ -1,6 +1,8 @@
 ﻿using System.Collections.Generic;
+using System.Data.Common;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 using Respawn.Graph;
 
 namespace Respawn
@@ -237,7 +239,10 @@ SELECT pg_temp.reset_sequence(s.sequence_name) FROM all_sequences s;";
         public string BuildTurnOffSystemVersioningCommandText(IEnumerable<TemporalTable> tablesToTurnOffSystemVersioning) => throw new System.NotImplementedException();
 
         public string BuildTurnOnSystemVersioningCommandText(IEnumerable<TemporalTable> tablesToTurnOnSystemVersioning) => throw new System.NotImplementedException();
-
-        public bool SupportsTemporalTables => false;
+        
+        public Task<bool> CheckSupportsTemporalTables(DbConnection connection)
+        {
+            return Task.FromResult(false);
+        }
     }
 }

--- a/Respawn/SqlServerDbAdapter.cs
+++ b/Respawn/SqlServerDbAdapter.cs
@@ -1,6 +1,9 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Data.Common;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 using Respawn.Graph;
 
 namespace Respawn
@@ -300,6 +303,13 @@ WHERE t.temporal_type = 2";
             return builder.ToString();
         }
 
-        public bool SupportsTemporalTables => true;
+        public Task<bool> CheckSupportsTemporalTables(DbConnection connection)
+        {
+            const int SqlServer2016MajorBuildVersion = 13;
+            var serverVersion = connection.ServerVersion;
+            var serverVersionDetails = serverVersion.Split(new[] { "." }, StringSplitOptions.None);
+            var versionNumber = int.Parse(serverVersionDetails[0]);
+            return Task.FromResult(versionNumber >= SqlServer2016MajorBuildVersion);
+        }
     }
 }


### PR DESCRIPTION
This PR fixes #86

- Replaced `IDbAdapter.SupportsTemporalTables` property with `IDbAdapter.CheckSupportsTemporalTables` method
- Added default implementation (**no** support for temporal tables) in order to not break code for users who implemented their own `IDbAdapter`
- Removed `Checkpoint.DoesDbSupportsTemporalTables` method which is SQL Server specific
- `Checkpoint.BuildDeleteTables` utilizes new method
- Fixed the incorrect check whether SQL Server supports Temporal Tables (as mentioned in the issue)

Please let me know if something is wrong or missing.

Best