### PR TITLE
fixed concat

### DIFF
--- a/Respawn/PostgresDbAdapter.cs
+++ b/Respawn/PostgresDbAdapter.cs
@@ -129,7 +129,7 @@ where 1=1";
                     {
                         var args = string.Join(",", tableGroup.Tables.Select(table => $"'{table.Schema}.{table.Name}'"));
 
-                        commandText += " AND tc.TABLE_SCHEMA + '.' + tc.TABLE_NAME NOT IN (" + args + ")";
+                        commandText += " AND tc.TABLE_SCHEMA || '.' || tc.TABLE_NAME NOT IN (" + args + ")";
                     }
                     else
                     {
@@ -157,7 +157,7 @@ where 1=1";
                     {
                         var args = string.Join(",", tableGroup.Tables.Select(table => $"'{table.Schema}.{table.Name}'"));
 
-                        commandText += " AND tc.TABLE_SCHEMA + '.' + tc.TABLE_NAME IN (" + args + ")";
+                        commandText += " AND tc.TABLE_SCHEMA || '.' || tc.TABLE_NAME IN (" + args + ")";
                     }
                     else
                     {


### PR DESCRIPTION
This pr replaces all `+` concatenations with `||` for Postgres

There was the issue #104 about error in Postgres:
> ERROR: operator does not exist: information_schema.sql_identifier + unknown

I faced the same problem with this piece of code:
```csharp
_respawner = await Respawner.CreateAsync(
    connection,
    new RespawnerOptions()
    {
        TablesToIgnore = new[] 
        {
            new Respawn.Graph.Table("schema_name", "my_table")
        },
        DbAdapter = DbAdapter.Postgres
    });
```
Probably, all concatenations should be with `||` like in pr #105