### PR TITLE
Set TargetFrameworks solely to "netstandard2.0"

### DIFF
--- a/Respawn/IDbAdapter.cs
+++ b/Respawn/IDbAdapter.cs
@@ -14,9 +14,6 @@ namespace Respawn
         string BuildReseedSql(IEnumerable<Table> tablesToDelete);
         string BuildTurnOffSystemVersioningCommandText(IEnumerable<TemporalTable> tablesToTurnOffSystemVersioning);
         string BuildTurnOnSystemVersioningCommandText(IEnumerable<TemporalTable> tablesToTurnOnSystemVersioning);
-        Task<bool> CheckSupportsTemporalTables(DbConnection connection)
-        {
-            return Task.FromResult(false);
-        }
+        Task<bool> CheckSupportsTemporalTables(DbConnection connection);
     }
 }

--- a/Respawn/Respawn.csproj
+++ b/Respawn/Respawn.csproj
@@ -4,7 +4,7 @@
     <Description>Intelligent resetting for database tests</Description>
     <Copyright>Copyright Jimmy Bogard</Copyright>
     <Authors>Jimmy Bogard</Authors>
-    <TargetFrameworks>netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <AssemblyName>Respawn</AssemblyName>
     <PackageId>Respawn</PackageId>
     <PackageTags>tests;integration tests;database tests</PackageTags>
@@ -26,9 +26,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.1" Condition="'$(TargetFramework)' == 'netstandard2.0'"/>
     <PackageReference Include="Microsoft.Data.SqlClient" Version="4.0.5" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="MinVer" Version="2.5.0" PrivateAssets="All" />
   </ItemGroup>
-  
+
 </Project>

--- a/Respawn/SqlServerDbAdapter.cs
+++ b/Respawn/SqlServerDbAdapter.cs
@@ -317,7 +317,11 @@ WHERE t.temporal_type = 2";
 
         private static async Task<int> GetEngineEdition(DbConnection connection)
         {
+#if NETSTANDARD2_0
+            using var command = connection.CreateCommand();
+#else
             await using var command = connection.CreateCommand();
+#endif
             command.CommandText = @"
 SELECT SERVERPROPERTY('EngineEdition');";
             var engineEdition = await command.ExecuteScalarAsync();
@@ -326,7 +330,11 @@ SELECT SERVERPROPERTY('EngineEdition');";
 
         private static async Task<byte> GetCompatibilityLevel(DbConnection connection)
         {
+#if NETSTANDARD2_0
+            using var command = connection.CreateCommand();
+#else
             await using var command = connection.CreateCommand();
+#endif
             command.CommandText = $@"
 SELECT compatibility_level
 FROM sys.databases


### PR DESCRIPTION
Hi @jbogard.

First of all, thank you for creating this lib.

Second, I would like to propose setting the TargetFrameworks solely to `netstandard2.0`. This change aims to increase the compatibility of the library with a broader range of projects, especially those that are not yet able to upgrade to newer .NET versions.

Changes included:
- Updated the TargetFrameworks in the project file(s) solely to `netstandard2.0`.
- Adjusted any code dependencies or features to ensure compatibility with `netstandard2.0`.

Benefits:
- Wider adoption and usability in legacy projects.
- Greater flexibility for developers working with diverse project setups.

Please let me know if there are any additional concerns or if further modifications are needed.

Looking forward to your feedback.