### PR TITLE
Update Microsoft.Data.SqlClient to 5.1.4 to address CVE-2023-36414

### DIFF
--- a/Respawn.DatabaseTests/Respawn.DatabaseTests.csproj
+++ b/Respawn.DatabaseTests/Respawn.DatabaseTests.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="4.0.5" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.4" />
     <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="3.21.90" />
   </ItemGroup>
   <ItemGroup>

--- a/Respawn.DatabaseTests/Respawn.DatabaseTests.csproj
+++ b/Respawn.DatabaseTests/Respawn.DatabaseTests.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.4" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.5" />
     <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="3.21.90" />
   </ItemGroup>
   <ItemGroup>

--- a/Respawn/Respawn.csproj
+++ b/Respawn/Respawn.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="4.0.5" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.4" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="MinVer" Version="2.5.0" PrivateAssets="All" />
   </ItemGroup>

--- a/Respawn/Respawn.csproj
+++ b/Respawn/Respawn.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.4" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.5" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="MinVer" Version="2.5.0" PrivateAssets="All" />
   </ItemGroup>


### PR DESCRIPTION
This project is [referencing](https://github.com/jbogard/Respawn/blob/2ad376db3da002d4b72386ec089f360b204de416/Respawn/Respawn.csproj#L29) Microsoft.Data.SqlClient version 4.0.5.
Version 4.0.5 references [Azure.Identity 1.3.0](https://github.com/dotnet/SqlClient/blob/13431168949a9a210341e493e75dcc420ca6be4a/tools/props/Versions.props#L23).

Version 1.3.0 of Azure.Identity does have a [vulnerability](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2023-36414). I would still recommend upgrading Microsoft.Data.SqlClient. The earliest fix for this is in [version 5.1.4](https://github.com/dotnet/SqlClient/releases/tag/v5.1.4), the vulnerability is also addressed in the release notes.


This fixes #140.

I'd recommend upgrading to 5.1.5 of [Microsoft.Data.SqlClient](https://github.com/dotnet/SqlClient/blob/01a589e54afe43c85c7607aa05f8605fa6f13bb3/tools/props/Versions.props#L33). This fixes [CVE-2024-21319](https://github.com/advisories/GHSA-59j7-ghrg-fj52) as well as the vulnerability mentioned above. This is mentioned in [these release notes ](https://github.com/dotnet/SqlClient/releases/tag/v5.1.5 )as well.