### PR TITLE
support database names containing special characters

### DIFF
--- a/Respawn/SqlServerDbAdapter.cs
+++ b/Respawn/SqlServerDbAdapter.cs
@@ -330,7 +330,7 @@ SELECT SERVERPROPERTY('EngineEdition');";
             command.CommandText = $@"
 SELECT compatibility_level
 FROM sys.databases
-WHERE name = '{connection.Database}';";
+WHERE name = N'{connection.Database}';";
 
             var result = await command.ExecuteScalarAsync();
             return result != null ? Convert.ToByte(result) : (byte)0;


### PR DESCRIPTION
Hi @jbogard,

I had troubles with the CheckTemporalTables property and it was because the query didn't work with database names containing special characters.

here's a fix.