### PR TITLE
Fix FormatDeleteStatement being ignored

### DIFF
--- a/Respawn/Respawner.cs
+++ b/Respawn/Respawner.cs
@@ -32,6 +32,7 @@ namespace Respawn
                     CheckTemporalTables = options.CheckTemporalTables,
                     WithReseed = options.WithReseed,
                     CommandTimeout = options.CommandTimeout,
+                    FormatDeleteStatement = options.FormatDeleteStatement,
                     DbAdapter = dbAdapter,
                 };
             }


### PR DESCRIPTION
This bug arose from merging both #137 and #151

#137 introduced a new `RespawnerOptions` property and #151 introduced a mechanism that copies all the `RespawnerOptions` properties.