### PR TITLE
Use fixtures to speed up database tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,13 @@ jobs:
     - name: Build and Test
       run: ./Build.ps1
       shell: pwsh
+    - name: Test Report
+      uses: dorny/test-reporter@v2
+      if: always()
+      with:
+        name: Test Report
+        path: artifacts/*.trx
+        reporter: dotnet-trx
     - name: Push to MyGet
       env:
         NUGET_URL: https://www.myget.org/F/respawn-ci/api/v3/index.json

--- a/Build.ps1
+++ b/Build.ps1
@@ -30,6 +30,6 @@ exec { & dotnet clean --configuration Release }
 
 exec { & dotnet build --configuration Release }
 
-exec { & dotnet test --configuration Release --results-directory $artifacts --no-build --logger trx --verbosity=normal }
+exec { & dotnet test --configuration Release --results-directory $artifacts --no-build --verbosity=normal }
 
 exec { & dotnet pack .\Respawn\Respawn.csproj --configuration Release --output $artifacts --no-build }

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <VSTestLogger>trx%3BLogFileName=$(MSBuildProjectName)-$(TargetFramework).trx</VSTestLogger>
+  </PropertyGroup>
+</Project>

--- a/Respawn.DatabaseTests/DB2Fixture.cs
+++ b/Respawn.DatabaseTests/DB2Fixture.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Data.Common;
+using DotNet.Testcontainers.Images;
+using IBM.Data.Db2;
+using NPoco;
+using Testcontainers.Db2;
+using Xunit.Abstractions;
+
+namespace Respawn.DatabaseTests;
+
+public class DB2Fixture(IMessageSink messageSink) : DbFixture<Db2Builder, Db2Container>(messageSink)
+{
+    public override DbProviderFactory DbProviderFactory => DB2Factory.Instance;
+
+    protected override DatabaseType DbType => null;
+
+    protected override Db2Builder CreateBuilder() => new Db2Builder(new DockerImage("icr.io/db2_community/db2:12.1.0.0", new Platform("amd64"))).WithAcceptLicenseAgreement(true);
+}

--- a/Respawn.DatabaseTests/DB2Tests.cs
+++ b/Respawn.DatabaseTests/DB2Tests.cs
@@ -1,50 +1,21 @@
 ﻿using Shouldly;
 using System;
 using System.Threading.Tasks;
-using DotNet.Testcontainers.Builders;
-using DotNet.Testcontainers.Images;
 using IBM.Data.Db2;
 using NPoco;
 using Respawn.Graph;
-using Testcontainers.Db2;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace Respawn.DatabaseTests
 {
-    public class DB2Tests : IAsyncLifetime
+    public class DB2Tests(ITestOutputHelper output, DB2Fixture fixture) : IAsyncLifetime, IClassFixture<DB2Fixture>
     {
-        private Db2Container _sqlContainer;
         private DB2Connection _connection;
-        private readonly ITestOutputHelper _output;
 
-        public DB2Tests(ITestOutputHelper output)
-        {
-            _output = output;
-        }
+        public async Task InitializeAsync() => _connection = (DB2Connection)await fixture.OpenConnectionAsync();
 
-        public async Task InitializeAsync()
-        {
-            _sqlContainer = new Db2Builder()
-                .WithAcceptLicenseAgreement(true)
-                .Build();
-            await _sqlContainer.StartAsync();
-            
-            _connection = new DB2Connection(_sqlContainer.GetConnectionString());
-
-            await _connection.OpenAsync();
-        }
-
-        public async Task DisposeAsync()
-        {
-            _connection?.Close();
-            _connection?.Dispose();
-            _connection = null;
-
-            await _sqlContainer.StopAsync();
-            await _sqlContainer.DisposeAsync();
-            _sqlContainer = null;
-        }
+        public async Task DisposeAsync() => await _connection.DisposeAsync();
 
         [SkipOnCI]
         public async Task ShouldDeleteData()
@@ -151,7 +122,7 @@ namespace Respawn.DatabaseTests
             }
             catch
             {
-                _output.WriteLine(checkPoint.DeleteSql ?? string.Empty);
+                output.WriteLine(checkPoint.DeleteSql ?? string.Empty);
                 throw;
             }
 
@@ -221,7 +192,7 @@ namespace Respawn.DatabaseTests
             }
             catch
             {
-                _output.WriteLine(checkPoint.DeleteSql ?? string.Empty);
+                output.WriteLine(checkPoint.DeleteSql ?? string.Empty);
                 throw;
             }
 
@@ -275,7 +246,7 @@ namespace Respawn.DatabaseTests
             }
             catch
             {
-                _output.WriteLine(checkPoint.DeleteSql ?? string.Empty);
+                output.WriteLine(checkPoint.DeleteSql ?? string.Empty);
                 throw;
             }
 
@@ -359,7 +330,7 @@ namespace Respawn.DatabaseTests
             }
             catch
             {
-                _output.WriteLine(checkPoint.DeleteSql ?? string.Empty);
+                output.WriteLine(checkPoint.DeleteSql ?? string.Empty);
                 throw;
             }
 
@@ -429,7 +400,7 @@ namespace Respawn.DatabaseTests
             }
             catch
             {
-                _output.WriteLine(checkPoint.DeleteSql ?? string.Empty);
+                output.WriteLine(checkPoint.DeleteSql ?? string.Empty);
                 throw;
             }
 
@@ -489,7 +460,7 @@ namespace Respawn.DatabaseTests
             }
             catch
             {
-                _output.WriteLine(checkPoint.DeleteSql ?? string.Empty);
+                output.WriteLine(checkPoint.DeleteSql ?? string.Empty);
                 throw;
             }
 

--- a/Respawn.DatabaseTests/DbFixture.cs
+++ b/Respawn.DatabaseTests/DbFixture.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Configurations;
+using DotNet.Testcontainers.Containers;
+using NPoco;
+using Testcontainers.Xunit;
+using Xunit.Abstractions;
+
+namespace Respawn.DatabaseTests;
+
+public abstract class DbFixture<TBuilderEntity, TContainerEntity>(IMessageSink messageSink) : DbContainerFixture<TBuilderEntity, TContainerEntity>(messageSink)
+    where TBuilderEntity : IContainerBuilder<TBuilderEntity, TContainerEntity, IContainerConfiguration>, new()
+    where TContainerEntity : IDatabaseContainer
+{
+    public async Task<IDatabase> CreateDatabaseAsync([CallerMemberName] string dbName = "")
+    {
+        await ExecuteCreateDatabaseAsync(dbName);
+
+        var connectionString = GetConnectionString(dbName);
+        var database = new Database(connectionString, DbType, DbProviderFactory);
+        return database.OpenSharedConnection();
+    }
+
+    protected abstract DatabaseType DbType { get; }
+
+    protected abstract TBuilderEntity CreateBuilder();
+
+    protected override TBuilderEntity Configure() => CreateBuilder().WithWaitStrategy(Wait.ForUnixContainer().UntilDatabaseIsAvailable(DbProviderFactory));
+
+    protected virtual async Task ExecuteCreateDatabaseAsync(string dbName)
+    {
+        var builder = DbProviderFactory.CreateCommandBuilder();
+        var sql = $"CREATE DATABASE {builder?.QuotePrefix}{dbName}{builder?.QuoteSuffix}";
+
+        await using var command = CreateCommand(sql);
+        await command.ExecuteNonQueryAsync();
+    }
+
+    protected virtual string GetConnectionString(string dbName)
+    {
+        var builder = DbProviderFactory.CreateConnectionStringBuilder() ?? throw new InvalidOperationException($"CreateConnectionStringBuilder returned null for {DbProviderFactory}");
+        builder.ConnectionString = ConnectionString;
+        builder["Database"] = dbName;
+        return builder.ToString();
+    }
+}

--- a/Respawn.DatabaseTests/EmptyDbTests.cs
+++ b/Respawn.DatabaseTests/EmptyDbTests.cs
@@ -23,7 +23,7 @@ namespace Respawn.DatabaseTests
 
         public async Task InitializeAsync()
         {
-            _msSqlContainer = new MsSqlBuilder().Build();
+            _msSqlContainer = new MsSqlBuilder("mcr.microsoft.com/mssql/server:2022-CU23-ubuntu-22.04").Build();
             await _msSqlContainer.StartAsync();
             
             var connString = _msSqlContainer.GetConnectionString();

--- a/Respawn.DatabaseTests/InformixFixture.cs
+++ b/Respawn.DatabaseTests/InformixFixture.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Data.Common;
+using System.IO;
+using Docker.DotNet.Models;
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Configurations;
+using DotNet.Testcontainers.Containers;
+using DotNet.Testcontainers.Images;
+using IBM.Data.Db2;
+using NPoco;
+using Xunit.Abstractions;
+
+namespace Respawn.DatabaseTests;
+
+public class InformixFixture(IMessageSink messageSink) : DbFixture<InformixBuilder, InformixContainer>(messageSink)
+{
+    public override DbProviderFactory DbProviderFactory => DB2Factory.Instance;
+
+    protected override DatabaseType DbType => null;
+
+    protected override InformixBuilder CreateBuilder()
+    {
+        return new InformixBuilder("ibmcom/informix-developer-database:14.10.FC5DE");
+    }
+}
+
+public sealed class InformixBuilder : ContainerBuilder<InformixBuilder, InformixContainer, ContainerConfiguration>
+{
+    public InformixBuilder()
+        : this("")
+    {
+        throw new NotSupportedException();
+    }
+
+    public InformixBuilder(string image)
+        : this(new DockerImage(image))
+    {
+    }
+
+    public InformixBuilder(IImage image)
+        : this(new ContainerConfiguration())
+    {
+        DockerResourceConfiguration = Init().WithImage(image).DockerResourceConfiguration;
+    }
+
+    private InformixBuilder(ContainerConfiguration configuration) : base(configuration)
+    {
+        DockerResourceConfiguration = configuration;
+    }
+
+    protected override ContainerConfiguration DockerResourceConfiguration { get; }
+
+    protected override InformixBuilder Init()
+    {
+        return base.Init()
+
+            // = environment:
+            .WithEnvironment("LICENSE", "accept")
+            .WithEnvironment("ONCONFIG_FILE", "onconfig")
+            .WithEnvironment("RUN_FILE_PRE_INIT", "my_post.sh")
+
+            // = ports:
+            .WithPortBinding(9088, assignRandomHostPort: true)
+            .WithPortBinding(9089, assignRandomHostPort: true)
+            .WithPortBinding(27017, assignRandomHostPort: true)
+            .WithPortBinding(27018, assignRandomHostPort: true)
+            .WithPortBinding(27883, assignRandomHostPort: true)
+
+            // = volumes:
+            .WithBindMount(
+                source: Path.GetFullPath("./informix-server"),
+                destination: "/opt/ibm/config",
+                AccessMode.ReadWrite)
+
+            // = privileged: true
+            .WithPrivileged(true)
+
+            // = user: root
+            //.WithUser("root")
+
+            // = tty: true
+            //.WithTty(true)
+
+            // optional: equivalent to "restart: always" but Testcontainers
+            // does not automatically restart containers (it recreates instead)
+            // .WithAutoRemove(false)
+
+            .WithWaitStrategy(Wait.ForUnixContainer()
+                .UntilExternalTcpPortIsAvailable(9088)
+                .UntilExternalTcpPortIsAvailable(9089)
+                .UntilInternalTcpPortIsAvailable(9088)
+                .UntilInternalTcpPortIsAvailable(9089)
+                // This is the last success message
+                .UntilMessageIsLogged("starting mqtt listener on port 27883")
+            );
+    }
+
+    public override InformixContainer Build()
+    {
+        Validate();
+        return new InformixContainer(DockerResourceConfiguration);
+    }
+
+    protected override InformixBuilder Clone(IResourceConfiguration<CreateContainerParameters> resourceConfiguration)
+    {
+        return Merge(DockerResourceConfiguration, new ContainerConfiguration(resourceConfiguration));
+    }
+
+    protected override InformixBuilder Clone(IContainerConfiguration resourceConfiguration)
+    {
+        return Merge(DockerResourceConfiguration, new ContainerConfiguration(resourceConfiguration));
+    }
+
+    protected override InformixBuilder Merge(ContainerConfiguration oldValue, ContainerConfiguration newValue)
+    {
+        return new InformixBuilder(new ContainerConfiguration(oldValue, newValue));
+    }
+}
+
+public sealed class InformixContainer(IContainerConfiguration configuration) : DockerContainer(configuration), IDatabaseContainer
+{
+    public string GetConnectionString()
+    {
+        var host = Hostname;
+        var port = GetMappedPublicPort(9089); // SQL port
+        return $"Server={host}:{port};Database=sysadmin;UID=informix;Password=in4mix;Persist Security Info=True;Authentication=Server;";
+    }
+}

--- a/Respawn.DatabaseTests/InformixTests.cs
+++ b/Respawn.DatabaseTests/InformixTests.cs
@@ -1,14 +1,6 @@
-﻿//#if INFORMIX
-using Respawn;
-using Shouldly;
+﻿using Shouldly;
 using System;
-using System.Data;
-using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
-using DotNet.Testcontainers.Builders;
-using DotNet.Testcontainers.Configurations;
-using DotNet.Testcontainers.Containers;
 using IBM.Data.Db2;
 using NPoco;
 using Respawn.Graph;
@@ -17,118 +9,22 @@ using Xunit.Abstractions;
 
 namespace Respawn.DatabaseTests
 {
-    public class InformixTests : IAsyncLifetime
+    public class InformixTests(ITestOutputHelper output, InformixFixture fixture) : IAsyncLifetime, IClassFixture<InformixFixture>
     {
         private DB2Connection _connection;
-        private readonly ITestOutputHelper _output;
-        private string _databaseName;
-        private IContainer _sqlContainer;
-
-        public InformixTests(ITestOutputHelper output)
-        {
-            _output = output;
-        }
-
-        public async Task DisposeAsync()
-        {
-            _connection?.Close();
-            _connection?.Dispose();
-            _connection = null;
-            
-            await _sqlContainer.StopAsync();
-            await _sqlContainer.DisposeAsync();
-            _sqlContainer = null;
-        }
 
         public async Task InitializeAsync()
         {
-            //const string connString = "Server=127.0.0.1:9089;Database=sysadmin;UID=informix;PWD=in4mix;Persist Security Info=True;Authentication=Server;";
+            var databaseName = $"dummyifx_{Guid.NewGuid():N}";
+            var createDbCommand = fixture.CreateCommand($"CREATE DATABASE {databaseName} WITH BUFFERED LOG");
+            await createDbCommand.ExecuteNonQueryAsync();
 
-            _sqlContainer = new ContainerBuilder()
-                .WithImage("ibmcom/informix-developer-database:14.10.FC5DE")
-
-                // = environment:
-                .WithEnvironment("LICENSE", "accept")
-                .WithEnvironment("ONCONFIG_FILE", "onconfig")
-                .WithEnvironment("RUN_FILE_PRE_INIT", "my_post.sh")
-
-                // = ports:
-                .WithPortBinding(9088, 9088)
-                .WithPortBinding(9089, 9089)
-                .WithPortBinding(27017, 27017)
-                .WithPortBinding(27018, 27018)
-                .WithPortBinding(27883, 27883)
-
-                // = volumes:
-                .WithBindMount(
-                    source: Path.GetFullPath("./informix-server"),
-                    destination: "/opt/ibm/config",
-                    AccessMode.ReadWrite)
-
-                // = privileged: true
-                .WithPrivileged(true)
-
-                // = user: root
-                //.WithUser("root")
-
-                // = tty: true
-                //.WithTty(true)
-
-                // optional: equivalent to "restart: always" but Testcontainers 
-                // does not automatically restart containers (it recreates instead)
-                // .WithAutoRemove(false)
-
-                .WithWaitStrategy(Wait.ForUnixContainer()
-                    .UntilExternalTcpPortIsAvailable(9088)
-                    .UntilExternalTcpPortIsAvailable(9089)
-                    .UntilInternalTcpPortIsAvailable(9088)
-                    .UntilInternalTcpPortIsAvailable(9089)
-                    // This is the last success message
-                    .UntilMessageIsLogged("starting mqtt listener on port 27883")
-                )
-                .Build();
-
-            await _sqlContainer.StartAsync();
-
-            var connString = GetConnectionString(_sqlContainer);
-            
-            await using (var connection = new DB2Connection(connString))
-            {
-                await connection.OpenAsync();
-                
-                using var database = new Database(connection);
-
-                _databaseName = $"dummyifx_{Guid.NewGuid():N}";
-
-                await database.ExecuteAsync($"CREATE DATABASE {_databaseName} WITH BUFFERED LOG;");
-            }
-
-            var testDbConnString = new DB2ConnectionStringBuilder(connString)
-            {
-                Database = _databaseName
-            }.ToString();
-
-            _connection = new DB2Connection(testDbConnString);
-
+            var connectionString = new DB2ConnectionStringBuilder(fixture.ConnectionString) { Database = databaseName }.ConnectionString;
+            _connection = new DB2Connection(connectionString);
             await _connection.OpenAsync();
         }
 
-        private static string GetConnectionString(
-            IContainer container,
-            string database = "sysadmin",
-            string user = "informix",
-            string password = "in4mix")
-        {
-            var host = container.Hostname;
-            var port = container.GetMappedPublicPort(9089);  // SQL port
-
-            return
-                $"Server={host}:{port};" +
-                $"Database={database};" +
-                $"UID={user};" +
-                $"Password={password};" +
-                $"Persist Security Info=True;Authentication=Server;";
-        }
+        public async Task DisposeAsync() => await _connection.DisposeAsync();
 
         [SkipOnCI]
         public async Task ShouldDeleteData()
@@ -222,7 +118,7 @@ namespace Respawn.DatabaseTests
             }
             catch
             {
-                _output.WriteLine(checkPoint.DeleteSql ?? string.Empty);
+                output.WriteLine(checkPoint.DeleteSql ?? string.Empty);
                 throw;
             }
 
@@ -284,7 +180,7 @@ namespace Respawn.DatabaseTests
             }
             catch
             {
-                _output.WriteLine(checkPoint.DeleteSql ?? string.Empty);
+                output.WriteLine(checkPoint.DeleteSql ?? string.Empty);
                 throw;
             }
 
@@ -331,7 +227,7 @@ namespace Respawn.DatabaseTests
             }
             catch
             {
-                _output.WriteLine(checkPoint.DeleteSql ?? string.Empty);
+                output.WriteLine(checkPoint.DeleteSql ?? string.Empty);
                 throw;
             }
 
@@ -410,7 +306,7 @@ namespace Respawn.DatabaseTests
             }
             catch
             {
-                _output.WriteLine(checkPoint.DeleteSql ?? string.Empty);
+                output.WriteLine(checkPoint.DeleteSql ?? string.Empty);
                 throw;
             }
 
@@ -461,7 +357,7 @@ namespace Respawn.DatabaseTests
             }
             catch
             {
-                _output.WriteLine(checkPoint.DeleteSql ?? string.Empty);
+                output.WriteLine(checkPoint.DeleteSql ?? string.Empty);
                 throw;
             }
 
@@ -504,7 +400,7 @@ namespace Respawn.DatabaseTests
             }
             catch
             {
-                _output.WriteLine(checkPoint.DeleteSql ?? string.Empty);
+                output.WriteLine(checkPoint.DeleteSql ?? string.Empty);
                 throw;
             }
 
@@ -516,11 +412,7 @@ namespace Respawn.DatabaseTests
 
         private async Task ManageUser(string userName)
         {
-            await using var connection = new DB2Connection($"Server=127.0.0.1:9089;Database={_databaseName};UID=informix;PWD=in4mix;Persist Security Info=True;Authentication=Server;");
-            await connection.OpenAsync();
-
-            //await using var allUsers = new DB2Command("SELECT username FROM sysusers", connection);
-            var database = new Database(connection);
+            var database = new Database(_connection);
 
             await database.ExecuteAsync($"DROP USER {userName};");
             await database.ExecuteAsync($"CREATE USER {userName} WITH PROPERTIES USER ifxsurr;");

--- a/Respawn.DatabaseTests/MySqlFixture.cs
+++ b/Respawn.DatabaseTests/MySqlFixture.cs
@@ -1,0 +1,16 @@
+using System.Data.Common;
+using MySql.Data.MySqlClient;
+using NPoco;
+using Testcontainers.MySql;
+using Xunit.Abstractions;
+
+namespace Respawn.DatabaseTests;
+
+public class MySqlFixture(IMessageSink messageSink) : DbFixture<MySqlBuilder, MySqlContainer>(messageSink)
+{
+    public override DbProviderFactory DbProviderFactory => MySqlClientFactory.Instance;
+
+    protected override DatabaseType DbType => DatabaseType.MySQL;
+
+    protected override MySqlBuilder CreateBuilder() => new MySqlBuilder("mysql:8.0").WithUsername("root");
+}

--- a/Respawn.DatabaseTests/MySqlTests.cs
+++ b/Respawn.DatabaseTests/MySqlTests.cs
@@ -1,24 +1,15 @@
 ﻿using System.Threading.Tasks;
-using MySql.Data.MySqlClient;
 using Respawn.Graph;
-using Testcontainers.MySql;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace Respawn.DatabaseTests
 {
-    using System;
     using System.Linq;
-    using NPoco;
     using Shouldly;
 
-    public class MySqlTests : IAsyncLifetime
+    public class MySqlTests(ITestOutputHelper output, MySqlFixture fixture) : IClassFixture<MySqlFixture>
     {
-        private readonly ITestOutputHelper _output;
-        private MySqlConnection _connection;
-        private IDatabase _database;
-        private MySqlContainer _sqlContainer;
-
         public class Foo
         {
             public int Value { get; set; }
@@ -28,59 +19,32 @@ namespace Respawn.DatabaseTests
             public int Value { get; set; }
         }
 
-        
-        public async Task InitializeAsync()
-        {
-            _sqlContainer = new MySqlBuilder()
-                .WithImage("mysql:8.0")
-                .WithDatabase("MySqlTests")
-                .Build();
-            await _sqlContainer.StartAsync();
-            
-            var connString = _sqlContainer.GetConnectionString();
-
-            _connection = new MySqlConnection(connString);
-            _connection.Open();
-            
-            _database = new Database(_connection);
-        }
-
-        public async Task DisposeAsync()
-        {
-            _connection?.Close();
-            _connection?.Dispose();
-            _connection = null;
-            await _sqlContainer.StopAsync();
-            await _sqlContainer.DisposeAsync();
-        }
-        
-        public MySqlTests(ITestOutputHelper output)
-        {
-            _output = output;
-        }
-
         [SkipOnCI]
         public async Task ShouldDeleteData()
         {
-            _database.Execute("drop table if exists Foo");
-            _database.Execute("CREATE TABLE `Foo` (`Value` int(3))");
+            using var db = await fixture.CreateDatabaseAsync();
 
-            _database.InsertBulk(Enumerable.Range(0, 100).Select(i => new Foo { Value = i }));
+            db.Execute("drop table if exists Foo");
+            db.Execute("CREATE TABLE `Foo` (`Value` int(3))");
 
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM Foo").ShouldBe(100);
+            db.InsertBulk(Enumerable.Range(0, 100).Select(i => new Foo { Value = i }));
 
-            var checkpoint = await Respawner.CreateAsync(_connection, new RespawnerOptions
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM Foo").ShouldBe(100);
+
+            var checkpoint = await Respawner.CreateAsync(db.Connection, new RespawnerOptions
             {
-                SchemasToInclude = new[] { "MySqlTests" }
+                SchemasToInclude = new[] { nameof(ShouldDeleteData) }
             });
-            await checkpoint.ResetAsync(_connection);
+            await checkpoint.ResetAsync(db.Connection);
 
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM Foo").ShouldBe(0);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM Foo").ShouldBe(0);
         }
 
         [SkipOnCI]
         public async Task ShouldDeleteDataWithRelationships()
         {
+            using var db = await fixture.CreateDatabaseAsync();
+
             // Tests a more complex scenario with 2 FK relationships
             
             // - Foo has both a PK and an FK relationship
@@ -89,17 +53,17 @@ namespace Respawn.DatabaseTests
 
             // It should delete the tables in the order Bar, Foo, Bob
 
-            _database.Execute("drop table if exists Bar");
-            _database.Execute("drop table if exists Foo");
-            _database.Execute("drop table if exists Bob");
+            db.Execute("drop table if exists Bar");
+            db.Execute("drop table if exists Foo");
+            db.Execute("drop table if exists Bob");
 
-            _database.Execute(@"
+            db.Execute(@"
 CREATE TABLE `Bob` (
   `BobValue` int(3) NOT NULL, 
   PRIMARY KEY (`BobValue`)
 )");
 
-            _database.Execute(@"
+            db.Execute(@"
 CREATE TABLE `Foo` (
   `FooValue` int(3) NOT NULL,
   `BobValue` int(3) NOT NULL,
@@ -108,7 +72,7 @@ CREATE TABLE `Foo` (
   CONSTRAINT `FK_FOO_BOB` FOREIGN KEY (`BobValue`) REFERENCES `Bob` (`BobValue`) ON DELETE NO ACTION ON UPDATE NO ACTION
 )");
 
-            _database.Execute(@"
+            db.Execute(@"
 CREATE TABLE `Bar` (
   `BarValue` int(3) NOT NULL,
   PRIMARY KEY (`BarValue`),
@@ -117,259 +81,275 @@ CREATE TABLE `Bar` (
 
             for (var i = 0; i < 100; i++)
             {
-                _database.Execute($"INSERT `Bob` VALUES ({i})");
-                _database.Execute($"INSERT `Foo` VALUES ({i},{i})");
-                _database.Execute($"INSERT `Bar` VALUES ({i})");
+                db.Execute($"INSERT `Bob` VALUES ({i})");
+                db.Execute($"INSERT `Foo` VALUES ({i},{i})");
+                db.Execute($"INSERT `Bar` VALUES ({i})");
             }
 
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM Foo").ShouldBe(100);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM Bar").ShouldBe(100);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM Bob").ShouldBe(100);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM Foo").ShouldBe(100);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM Bar").ShouldBe(100);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM Bob").ShouldBe(100);
 
-            var checkpoint = await Respawner.CreateAsync(_connection, new RespawnerOptions
+            var checkpoint = await Respawner.CreateAsync(db.Connection, new RespawnerOptions
             {
-                SchemasToInclude = new[] { "MySqlTests" }
+                SchemasToInclude = new[] { nameof(ShouldDeleteDataWithRelationships) }
             });
-            await checkpoint.ResetAsync(_connection);
+            await checkpoint.ResetAsync(db.Connection);
 
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM Foo").ShouldBe(0);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM Bar").ShouldBe(0);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM Bob").ShouldBe(0);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM Foo").ShouldBe(0);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM Bar").ShouldBe(0);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM Bob").ShouldBe(0);
         }
 
         [SkipOnCI]
         public async Task ShouldHandleSelfRelationships()
         {
-            _database.Execute("create table foo (id int primary key, parentid int NULL)");
-            _database.Execute("alter table foo add constraint FK_Parent foreign key (parentid) references foo (id)");
+            using var db = await fixture.CreateDatabaseAsync();
 
-            _database.Execute("INSERT INTO `foo` (id) VALUES (@0)", 1);
+            db.Execute("create table foo (id int primary key, parentid int NULL)");
+            db.Execute("alter table foo add constraint FK_Parent foreign key (parentid) references foo (id)");
+
+            db.Execute("INSERT INTO `foo` (id) VALUES (@0)", 1);
             for (int i = 1; i < 100; i++)
             {
-                _database.Execute("INSERT INTO `foo` VALUES (@0, @1)", i + 1, i);
+                db.Execute("INSERT INTO `foo` VALUES (@0, @1)", i + 1, i);
             }
 
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM foo").ShouldBe(100);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM foo").ShouldBe(100);
 
-            var checkpoint = await Respawner.CreateAsync(_connection, new RespawnerOptions
+            var checkpoint = await Respawner.CreateAsync(db.Connection, new RespawnerOptions
             {
-                SchemasToInclude = new[] { "MySqlTests" }
+                SchemasToInclude = new[] { nameof(ShouldHandleSelfRelationships) }
             });
             try
             {
-                await checkpoint.ResetAsync(_connection);
+                await checkpoint.ResetAsync(db.Connection);
             }
             catch
             {
-                _output.WriteLine(checkpoint.DeleteSql ?? string.Empty);
+                output.WriteLine(checkpoint.DeleteSql ?? string.Empty);
                 throw;
             }
 
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM foo").ShouldBe(0);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM foo").ShouldBe(0);
         }
 
 
         [SkipOnCI]
         public async Task ShouldHandleCircularRelationships()
         {
-            _database.Execute("create table parent (id int primary key, childid int NULL)");
-            _database.Execute("create table child (id int primary key, parentid int NULL)");
-            _database.Execute("alter table parent add constraint FK_Child foreign key (ChildId) references child (Id)");
-            _database.Execute("alter table child add constraint FK_Parent foreign key (ParentId) references parent (Id)");
+            using var db = await fixture.CreateDatabaseAsync();
+
+            db.Execute("create table parent (id int primary key, childid int NULL)");
+            db.Execute("create table child (id int primary key, parentid int NULL)");
+            db.Execute("alter table parent add constraint FK_Child foreign key (ChildId) references child (Id)");
+            db.Execute("alter table child add constraint FK_Parent foreign key (ParentId) references parent (Id)");
 
             for (int i = 0; i < 100; i++)
             {
-                _database.Execute("INSERT INTO parent VALUES (@0, null)", i);
-                _database.Execute("INSERT INTO child VALUES (@0, null)", i);
+                db.Execute("INSERT INTO parent VALUES (@0, null)", i);
+                db.Execute("INSERT INTO child VALUES (@0, null)", i);
             }
 
-            _database.Execute("update parent set childid = 0");
-            _database.Execute("update child set parentid = 1");
+            db.Execute("update parent set childid = 0");
+            db.Execute("update child set parentid = 1");
 
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM parent").ShouldBe(100);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM child").ShouldBe(100);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM parent").ShouldBe(100);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM child").ShouldBe(100);
 
-            var checkpoint = await Respawner.CreateAsync(_connection, new RespawnerOptions
+            var checkpoint = await Respawner.CreateAsync(db.Connection, new RespawnerOptions
             {
-                SchemasToInclude = new[] { "MySqlTests" }
+                SchemasToInclude = new[] { nameof(ShouldHandleCircularRelationships) }
             });
-            await checkpoint.ResetAsync(_connection);
+            await checkpoint.ResetAsync(db.Connection);
 
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM parent").ShouldBe(0);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM child").ShouldBe(0);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM parent").ShouldBe(0);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM child").ShouldBe(0);
         }
 
         [SkipOnCI]
         public async Task ShouldHandleComplexCycles()
         {
-            _database.Execute("create table a (id int primary key, b_id int NULL)");
-            _database.Execute("create table b (id int primary key, a_id int NULL, c_id int NULL, d_id int NULL)");
-            _database.Execute("create table c (id int primary key, d_id int NULL)");
-            _database.Execute("create table d (id int primary key)");
-            _database.Execute("create table e (id int primary key, a_id int NULL)");
-            _database.Execute("create table f (id int primary key, b_id int NULL)");
-            _database.Execute("alter table a add constraint FK_a_b foreign key (b_id) references b (id)");
-            _database.Execute("alter table b add constraint FK_b_a foreign key (a_id) references a (id)");
-            _database.Execute("alter table b add constraint FK_b_c foreign key (c_id) references c (id)");
-            _database.Execute("alter table b add constraint FK_b_d foreign key (d_id) references d (id)");
-            _database.Execute("alter table c add constraint FK_c_d foreign key (d_id) references d (id)");
-            _database.Execute("alter table e add constraint FK_e_a foreign key (a_id) references a (id)");
-            _database.Execute("alter table f add constraint FK_f_b foreign key (b_id) references b (id)");
+            using var db = await fixture.CreateDatabaseAsync();
+
+            db.Execute("create table a (id int primary key, b_id int NULL)");
+            db.Execute("create table b (id int primary key, a_id int NULL, c_id int NULL, d_id int NULL)");
+            db.Execute("create table c (id int primary key, d_id int NULL)");
+            db.Execute("create table d (id int primary key)");
+            db.Execute("create table e (id int primary key, a_id int NULL)");
+            db.Execute("create table f (id int primary key, b_id int NULL)");
+            db.Execute("alter table a add constraint FK_a_b foreign key (b_id) references b (id)");
+            db.Execute("alter table b add constraint FK_b_a foreign key (a_id) references a (id)");
+            db.Execute("alter table b add constraint FK_b_c foreign key (c_id) references c (id)");
+            db.Execute("alter table b add constraint FK_b_d foreign key (d_id) references d (id)");
+            db.Execute("alter table c add constraint FK_c_d foreign key (d_id) references d (id)");
+            db.Execute("alter table e add constraint FK_e_a foreign key (a_id) references a (id)");
+            db.Execute("alter table f add constraint FK_f_b foreign key (b_id) references b (id)");
 
 
-            _database.Execute("insert into d (id) values (1)");
-            _database.Execute("insert into c (id, d_id) values (1, 1)");
-            _database.Execute("insert into a (id) values (1)");
-            _database.Execute("insert into b (id, c_id, d_id) values (1, 1, 1)");
-            _database.Execute("insert into e (id, a_id) values (1, 1)");
-            _database.Execute("insert into f (id, b_id) values (1, 1)");
-            _database.Execute("update a set b_id = 1");
-            _database.Execute("update b set a_id = 1");
+            db.Execute("insert into d (id) values (1)");
+            db.Execute("insert into c (id, d_id) values (1, 1)");
+            db.Execute("insert into a (id) values (1)");
+            db.Execute("insert into b (id, c_id, d_id) values (1, 1, 1)");
+            db.Execute("insert into e (id, a_id) values (1, 1)");
+            db.Execute("insert into f (id, b_id) values (1, 1)");
+            db.Execute("update a set b_id = 1");
+            db.Execute("update b set a_id = 1");
 
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM a").ShouldBe(1);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM b").ShouldBe(1);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM c").ShouldBe(1);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM d").ShouldBe(1);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM e").ShouldBe(1);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM f").ShouldBe(1);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM a").ShouldBe(1);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM b").ShouldBe(1);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM c").ShouldBe(1);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM d").ShouldBe(1);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM e").ShouldBe(1);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM f").ShouldBe(1);
 
-            var checkpoint = await Respawner.CreateAsync(_connection, new RespawnerOptions
+            var checkpoint = await Respawner.CreateAsync(db.Connection, new RespawnerOptions
             {
-                SchemasToInclude = new[] { "MySqlTests" }
+                SchemasToInclude = new[] { nameof(ShouldHandleComplexCycles) }
             });
             try
             {
-                await checkpoint.ResetAsync(_connection);
+                await checkpoint.ResetAsync(db.Connection);
             }
             catch
             {
-                _output.WriteLine(checkpoint.DeleteSql ?? string.Empty);
+                output.WriteLine(checkpoint.DeleteSql ?? string.Empty);
                 throw;
             }
 
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM a").ShouldBe(0);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM b").ShouldBe(0);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM c").ShouldBe(0);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM d").ShouldBe(0);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM e").ShouldBe(0);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM f").ShouldBe(0);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM a").ShouldBe(0);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM b").ShouldBe(0);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM c").ShouldBe(0);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM d").ShouldBe(0);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM e").ShouldBe(0);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM f").ShouldBe(0);
         }
 
         [SkipOnCI]
         public async Task ShouldIgnoreTables()
         {
-            _database.Execute("drop table if exists Foo");
-            _database.Execute("drop table if exists Bar");
-            _database.Execute("create table `Foo` (`Value` int(3))");
-            _database.Execute("create table `Bar` (`Value` int(3))");
+            using var db = await fixture.CreateDatabaseAsync();
 
-            _database.InsertBulk(Enumerable.Range(0, 100).Select(i => new Foo { Value = i }));
-            _database.InsertBulk(Enumerable.Range(0, 100).Select(i => new Bar { Value = i }));
+            db.Execute("drop table if exists Foo");
+            db.Execute("drop table if exists Bar");
+            db.Execute("create table `Foo` (`Value` int(3))");
+            db.Execute("create table `Bar` (`Value` int(3))");
 
-            var checkpoint = await Respawner.CreateAsync(_connection, new RespawnerOptions
+            db.InsertBulk(Enumerable.Range(0, 100).Select(i => new Foo { Value = i }));
+            db.InsertBulk(Enumerable.Range(0, 100).Select(i => new Bar { Value = i }));
+
+            var checkpoint = await Respawner.CreateAsync(db.Connection, new RespawnerOptions
             {
                 TablesToIgnore = new Table[] { "Foo" },
-                SchemasToInclude = new[] { "MySqlTests" }
+                SchemasToInclude = new[] { nameof(ShouldIgnoreTables) }
             });
-            await checkpoint.ResetAsync(_connection);
+            await checkpoint.ResetAsync(db.Connection);
 
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM Foo").ShouldBe(100);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM Bar").ShouldBe(0);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM Foo").ShouldBe(100);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM Bar").ShouldBe(0);
         }
 
         [SkipOnCI]
         public async Task ShouldIncludeTables()
         {
-            _database.Execute("drop table if exists Foo");
-            _database.Execute("drop table if exists Bar");
-            _database.Execute("create table `Foo` (`Value` int(3))");
-            _database.Execute("create table `Bar` (`Value` int(3))");
+            using var db = await fixture.CreateDatabaseAsync();
 
-            _database.InsertBulk(Enumerable.Range(0, 100).Select(i => new Foo { Value = i }));
-            _database.InsertBulk(Enumerable.Range(0, 100).Select(i => new Bar { Value = i }));
+            db.Execute("drop table if exists Foo");
+            db.Execute("drop table if exists Bar");
+            db.Execute("create table `Foo` (`Value` int(3))");
+            db.Execute("create table `Bar` (`Value` int(3))");
 
-            var checkpoint = await Respawner.CreateAsync(_connection, new RespawnerOptions
+            db.InsertBulk(Enumerable.Range(0, 100).Select(i => new Foo { Value = i }));
+            db.InsertBulk(Enumerable.Range(0, 100).Select(i => new Bar { Value = i }));
+
+            var checkpoint = await Respawner.CreateAsync(db.Connection, new RespawnerOptions
             {
                 TablesToInclude = new Table[] { "Foo" },
-                SchemasToInclude = new[] { "MySqlTests" }
+                SchemasToInclude = new[] { nameof(ShouldIncludeTables) }
             });
-            await checkpoint.ResetAsync(_connection);
+            await checkpoint.ResetAsync(db.Connection);
 
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM Foo").ShouldBe(0);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM Bar").ShouldBe(100);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM Foo").ShouldBe(0);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM Bar").ShouldBe(100);
         }
 
         [SkipOnCI]
         public async Task ShouldExcludeSchemas()
         {
-            _database.Execute("drop table if exists `A`.`Foo`");
-            _database.Execute("drop table if exists `B`.`Bar`");
-            _database.Execute("drop schema if exists `A`");
-            _database.Execute("drop schema if exists `B`");
-            _database.Execute("create schema `A`");
-            _database.Execute("create schema `B`");
-            _database.Execute("create table `A`.`Foo` (`Value` int(3))");
-            _database.Execute("create table `B`.`Bar` (`Value` int(3))");
+            using var db = await fixture.CreateDatabaseAsync();
+
+            db.Execute("drop table if exists `A`.`Foo`");
+            db.Execute("drop table if exists `B`.`Bar`");
+            db.Execute("drop schema if exists `A`");
+            db.Execute("drop schema if exists `B`");
+            db.Execute("create schema `A`");
+            db.Execute("create schema `B`");
+            db.Execute("create table `A`.`Foo` (`Value` int(3))");
+            db.Execute("create table `B`.`Bar` (`Value` int(3))");
 
             for (var i = 0; i < 100; i++)
             {
-                _database.Execute("INSERT `A`.`Foo` VALUES (" + i + ")");
-                _database.Execute("INSERT `B`.`Bar` VALUES (" + i + ")");
+                db.Execute("INSERT `A`.`Foo` VALUES (" + i + ")");
+                db.Execute("INSERT `B`.`Bar` VALUES (" + i + ")");
             }
 
-            var checkpoint = await Respawner.CreateAsync(_connection, new RespawnerOptions
+            var checkpoint = await Respawner.CreateAsync(db.Connection, new RespawnerOptions
             {
-                SchemasToExclude = new[] { "A", "MySqlTests" }
+                SchemasToExclude = new[] { "A", nameof(ShouldExcludeSchemas) }
             });
-            await checkpoint.ResetAsync(_connection);
+            await checkpoint.ResetAsync(db.Connection);
 
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM A.Foo").ShouldBe(100);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM B.Bar").ShouldBe(0);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM A.Foo").ShouldBe(100);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM B.Bar").ShouldBe(0);
         }
 
         [SkipOnCI]
         public async Task ShouldIncludeSchemas()
         {
-            _database.Execute("drop table if exists `A`.`Foo`");
-            _database.Execute("drop table if exists `B`.`Bar`");
-            _database.Execute("drop schema if exists `A`");
-            _database.Execute("drop schema if exists `B`");
-            _database.Execute("create schema `A`");
-            _database.Execute("create schema `B`");
-            _database.Execute("create table `A`.`Foo` (`Value` int(3))");
-            _database.Execute("create table `B`.`Bar` (`Value` int(3))");
+            using var db = await fixture.CreateDatabaseAsync();
+
+            db.Execute("drop table if exists `A`.`Foo`");
+            db.Execute("drop table if exists `B`.`Bar`");
+            db.Execute("drop schema if exists `A`");
+            db.Execute("drop schema if exists `B`");
+            db.Execute("create schema `A`");
+            db.Execute("create schema `B`");
+            db.Execute("create table `A`.`Foo` (`Value` int(3))");
+            db.Execute("create table `B`.`Bar` (`Value` int(3))");
 
             for (var i = 0; i < 100; i++)
             {
-                _database.Execute("INSERT A.Foo VALUES (" + i + ")");
-                _database.Execute("INSERT B.Bar VALUES (" + i + ")");
+                db.Execute("INSERT A.Foo VALUES (" + i + ")");
+                db.Execute("INSERT B.Bar VALUES (" + i + ")");
             }
 
-            var checkpoint = await Respawner.CreateAsync(_connection, new RespawnerOptions
+            var checkpoint = await Respawner.CreateAsync(db.Connection, new RespawnerOptions
             {
                 SchemasToInclude = new[] { "B" }
             });
-            await checkpoint.ResetAsync(_connection);
+            await checkpoint.ResetAsync(db.Connection);
 
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM A.Foo").ShouldBe(100);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM B.Bar").ShouldBe(0);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM A.Foo").ShouldBe(100);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM B.Bar").ShouldBe(0);
         }
 
         [SkipOnCI]
         public async Task ShouldResetSequencesAndIdentities()
         {
-            _database.Execute("CREATE TABLE a (id INT NOT NULL AUTO_INCREMENT PRIMARY KEY)");
-            _database.Execute("INSERT INTO a(id) VALUES (0)");
-            _database.Execute("INSERT INTO a(id) VALUES (0)");
-            _database.Execute("INSERT INTO a(id) VALUES (0)");
+            using var db = await fixture.CreateDatabaseAsync();
 
-            var checkpoint = await Respawner.CreateAsync(_connection, new RespawnerOptions
+            db.Execute("CREATE TABLE a (id INT NOT NULL AUTO_INCREMENT PRIMARY KEY)");
+            db.Execute("INSERT INTO a(id) VALUES (0)");
+            db.Execute("INSERT INTO a(id) VALUES (0)");
+            db.Execute("INSERT INTO a(id) VALUES (0)");
+
+            var checkpoint = await Respawner.CreateAsync(db.Connection, new RespawnerOptions
             {
                 WithReseed = true
             });
 
-            await checkpoint.ResetAsync(_connection);
-            _database.ExecuteScalar<int>("SELECT AUTO_INCREMENT FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'MySqlTests' AND TABLE_NAME = 'a';").ShouldBe(1);
+            await checkpoint.ResetAsync(db.Connection);
+            db.ExecuteScalar<int>($"SELECT AUTO_INCREMENT FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = '{nameof(ShouldResetSequencesAndIdentities)}' AND TABLE_NAME = 'a';").ShouldBe(1);
         }
 
     }

--- a/Respawn.DatabaseTests/MySqlTests.cs
+++ b/Respawn.DatabaseTests/MySqlTests.cs
@@ -19,7 +19,7 @@ namespace Respawn.DatabaseTests
             public int Value { get; set; }
         }
 
-        [SkipOnCI]
+        [Fact]
         public async Task ShouldDeleteData()
         {
             using var db = await fixture.CreateDatabaseAsync();
@@ -40,7 +40,7 @@ namespace Respawn.DatabaseTests
             db.ExecuteScalar<int>("SELECT COUNT(1) FROM Foo").ShouldBe(0);
         }
 
-        [SkipOnCI]
+        [Fact]
         public async Task ShouldDeleteDataWithRelationships()
         {
             using var db = await fixture.CreateDatabaseAsync();
@@ -101,7 +101,7 @@ CREATE TABLE `Bar` (
             db.ExecuteScalar<int>("SELECT COUNT(1) FROM Bob").ShouldBe(0);
         }
 
-        [SkipOnCI]
+        [Fact]
         public async Task ShouldHandleSelfRelationships()
         {
             using var db = await fixture.CreateDatabaseAsync();
@@ -135,7 +135,7 @@ CREATE TABLE `Bar` (
         }
 
 
-        [SkipOnCI]
+        [Fact]
         public async Task ShouldHandleCircularRelationships()
         {
             using var db = await fixture.CreateDatabaseAsync();
@@ -167,7 +167,7 @@ CREATE TABLE `Bar` (
             db.ExecuteScalar<int>("SELECT COUNT(1) FROM child").ShouldBe(0);
         }
 
-        [SkipOnCI]
+        [Fact]
         public async Task ShouldHandleComplexCycles()
         {
             using var db = await fixture.CreateDatabaseAsync();
@@ -225,7 +225,7 @@ CREATE TABLE `Bar` (
             db.ExecuteScalar<int>("SELECT COUNT(1) FROM f").ShouldBe(0);
         }
 
-        [SkipOnCI]
+        [Fact]
         public async Task ShouldIgnoreTables()
         {
             using var db = await fixture.CreateDatabaseAsync();
@@ -249,7 +249,7 @@ CREATE TABLE `Bar` (
             db.ExecuteScalar<int>("SELECT COUNT(1) FROM Bar").ShouldBe(0);
         }
 
-        [SkipOnCI]
+        [Fact]
         public async Task ShouldIncludeTables()
         {
             using var db = await fixture.CreateDatabaseAsync();
@@ -273,7 +273,7 @@ CREATE TABLE `Bar` (
             db.ExecuteScalar<int>("SELECT COUNT(1) FROM Bar").ShouldBe(100);
         }
 
-        [SkipOnCI]
+        [Fact]
         public async Task ShouldExcludeSchemas()
         {
             using var db = await fixture.CreateDatabaseAsync();
@@ -303,7 +303,7 @@ CREATE TABLE `Bar` (
             db.ExecuteScalar<int>("SELECT COUNT(1) FROM B.Bar").ShouldBe(0);
         }
 
-        [SkipOnCI]
+        [Fact]
         public async Task ShouldIncludeSchemas()
         {
             using var db = await fixture.CreateDatabaseAsync();
@@ -333,7 +333,7 @@ CREATE TABLE `Bar` (
             db.ExecuteScalar<int>("SELECT COUNT(1) FROM B.Bar").ShouldBe(0);
         }
 
-        [SkipOnCI]
+        [Fact]
         public async Task ShouldResetSequencesAndIdentities()
         {
             using var db = await fixture.CreateDatabaseAsync();

--- a/Respawn.DatabaseTests/OracleFixture.cs
+++ b/Respawn.DatabaseTests/OracleFixture.cs
@@ -1,0 +1,68 @@
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Threading.Tasks;
+using NPoco;
+using Oracle.ManagedDataAccess.Client;
+using Testcontainers.Oracle;
+using Xunit.Abstractions;
+
+namespace Respawn.DatabaseTests;
+
+public class OracleFixture(IMessageSink messageSink) : DbFixture<OracleBuilder, OracleContainer>(messageSink)
+{
+    private string _serviceName;
+
+    public override DbProviderFactory DbProviderFactory => OracleClientFactory.Instance;
+
+    protected override DatabaseType DbType => DatabaseType.OracleManaged;
+
+    protected override OracleBuilder CreateBuilder() => new("gvenzl/oracle-free:23-slim-faststart");
+
+    protected override async Task InitializeAsync()
+    {
+        await base.InitializeAsync();
+
+        _serviceName = (string)(await ExecuteSqlAsSysDbaAsync(["SELECT NAME from V$PDBS"]))[0];
+    }
+
+    public string User => OracleBuilder.DefaultUsername.ToUpperInvariant();
+
+    protected override async Task ExecuteCreateDatabaseAsync(string dbName)
+    {
+        var builder = new OracleConnectionStringBuilder(ConnectionString);
+
+        await ExecuteSqlAsSysDbaAsync([
+            "ALTER SESSION SET CONTAINER=CDB$ROOT",
+            $"CREATE PLUGGABLE DATABASE {dbName} ADMIN USER {builder.UserID} IDENTIFIED BY {builder.Password} FILE_NAME_CONVERT = ('pdbseed', '{dbName}')",
+            $"ALTER PLUGGABLE DATABASE {dbName} OPEN",
+            $"ALTER SESSION SET CONTAINER={dbName}",
+            $"GRANT ALL PRIVILEGES TO {builder.UserID}",
+        ]);
+    }
+
+    protected override string GetConnectionString(string dbName)
+    {
+        var builder = new OracleConnectionStringBuilder(ConnectionString);
+        var connectionString = builder.ConnectionString.Replace(_serviceName, dbName);
+        return connectionString;
+    }
+
+    private async Task<List<object>> ExecuteSqlAsSysDbaAsync(string[] sqlScripts)
+    {
+        var connectionString = new OracleConnectionStringBuilder(ConnectionString) { UserID = "SYS", DBAPrivilege = "SYSDBA" }.ConnectionString;
+        await using var connection = new OracleConnection(connectionString);
+        await connection.OpenAsync();
+        await using var command = connection.CreateCommand();
+
+        var results = new List<object>(sqlScripts.Length);
+
+        foreach (var sqlScript in sqlScripts)
+        {
+            command.CommandText = sqlScript;
+            var result = await command.ExecuteScalarAsync();
+            results.Add(result);
+        }
+
+        return results;
+    }
+}

--- a/Respawn.DatabaseTests/OracleTests.cs
+++ b/Respawn.DatabaseTests/OracleTests.cs
@@ -1,440 +1,406 @@
-﻿using Testcontainers.Oracle;
+﻿using System;
+using System.Threading.Tasks;
+using NPoco;
+using Respawn.Graph;
+using Shouldly;
+using Xunit;
 using Xunit.Abstractions;
 
-#if ORACLE
 namespace Respawn.DatabaseTests
 {
-    using System;
-    using System.Threading.Tasks;
-    using NPoco;
-    using Oracle.ManagedDataAccess.Client;
-    using Respawn.Graph;
-    using Shouldly;
-    using Xunit;
-
-    public class OracleTests : IAsyncLifetime
+    public class OracleTests(ITestOutputHelper output, OracleFixture fixture) : IClassFixture<OracleFixture>
     {
-        private readonly ITestOutputHelper _output;
-        private OracleConnection _connection;
-        private Database _database;
-        private string _createdUser;
-        private OracleContainer _sqlContainer;
-
-        public class Foo
-        {
-            public int Value { get; set; }
-        }
-        public class Bar
-        {
-            public int Value { get; set; }
-        }
-
-        public OracleTests(ITestOutputHelper output)
-        {
-            _output = output;
-        }
-
-        public async Task InitializeAsync()
-        {
-            _createdUser = Guid.NewGuid().ToString().Substring(0, 8);
-
-            
-            _sqlContainer = new OracleBuilder("gvenzl/oracle-free:23-slim-faststart")
-                .WithUsername(_createdUser)
-                .Build();
-            await _sqlContainer.StartAsync();
-
-            var connString = _sqlContainer.GetConnectionString();
-            
-            _connection = new OracleConnection(connString);
-            await _connection.OpenAsync();
-
-            _database = new Database(_connection, DatabaseType.OracleManaged);
-        }
-
-        
-        public async Task DisposeAsync()
-        {
-            _database.Dispose();
-            _database = null;
-
-            _connection.Close();
-            _connection.Dispose();
-            _connection = null;
-
-            await _sqlContainer.StopAsync();
-            await _sqlContainer.DisposeAsync();
-        }
-        
         [SkipOnCI]
         public async Task ShouldDeleteData()
         {
-            await _database.ExecuteAsync("create table \"foo\" (value int)");
+            using var db = await fixture.CreateDatabaseAsync();
+
+            await db.ExecuteAsync("create table \"foo\" (value int)");
 
             for (int i = 0; i < 100; i++)
             {
-                await _database.ExecuteAsync("INSERT INTO \"foo\" VALUES (@0)", i);
+                await db.ExecuteAsync("INSERT INTO \"foo\" VALUES (@0)", i);
             }
 
-            (await _database.ExecuteScalarAsync<int>("SELECT COUNT(1) FROM \"foo\"")).ShouldBe(100);
+            (await db.ExecuteScalarAsync<int>("SELECT COUNT(1) FROM \"foo\"")).ShouldBe(100);
 
-            var respawner = await Respawner.CreateAsync(_connection, new RespawnerOptions
+            var respawner = await Respawner.CreateAsync(db.Connection, new RespawnerOptions
             {
-                SchemasToInclude = new[] { _createdUser }
+                SchemasToInclude = new[] { fixture.User }
             });
             try
             {
-                await respawner.ResetAsync(_connection);
+                await respawner.ResetAsync(db.Connection);
             }
             finally
             {
-                _output.WriteLine(_createdUser);
-                _output.WriteLine(respawner.DeleteSql);
+                output.WriteLine(respawner.DeleteSql);
             }
 
-            (await _database.ExecuteScalarAsync<int>("SELECT COUNT(1) FROM \"foo\"")).ShouldBe(0);
+            (await db.ExecuteScalarAsync<int>("SELECT COUNT(1) FROM \"foo\"")).ShouldBe(0);
         }
 
         [SkipOnCI]
         public async Task ShouldDeleteMultipleTables()
         {
-            await _database.ExecuteAsync("create table \"foo\" (value int)");
-            await _database.ExecuteAsync("create table \"bar\" (value int)");
+            using var db = await fixture.CreateDatabaseAsync();
+
+            await db.ExecuteAsync("create table \"foo\" (value int)");
+            await db.ExecuteAsync("create table \"bar\" (value int)");
 
             for (int i = 0; i < 100; i++)
             {
-                await _database.ExecuteAsync("INSERT INTO \"foo\" VALUES (@0)", i);
-                await _database.ExecuteAsync("INSERT INTO \"bar\" VALUES (@0)", i);
+                await db.ExecuteAsync("INSERT INTO \"foo\" VALUES (@0)", i);
+                await db.ExecuteAsync("INSERT INTO \"bar\" VALUES (@0)", i);
             }
 
-            var respawner = await Respawner.CreateAsync(_connection, new RespawnerOptions
+            var respawner = await Respawner.CreateAsync(db.Connection, new RespawnerOptions
             {
-                SchemasToInclude = new[] { _createdUser },
+                SchemasToInclude = new[] { fixture.User },
             });
-            await respawner.ResetAsync(_connection);
+            await respawner.ResetAsync(db.Connection);
 
-            (await _database.ExecuteScalarAsync<int>("SELECT COUNT(1) FROM \"foo\"")).ShouldBe(0);
-            (await _database.ExecuteScalarAsync<int>("SELECT COUNT(1) FROM \"bar\"")).ShouldBe(0);
+            (await db.ExecuteScalarAsync<int>("SELECT COUNT(1) FROM \"foo\"")).ShouldBe(0);
+            (await db.ExecuteScalarAsync<int>("SELECT COUNT(1) FROM \"bar\"")).ShouldBe(0);
         }
 
         [SkipOnCI]
         public async Task ShouldHandleRelationships()
         {
-            _database.Execute("create table \"foo\" (value int, primary key (value))");
-            _database.Execute("create table \"baz\" (value int, foovalue int, constraint FK_Foo foreign key (foovalue) references \"foo\" (value))");
+            using var db = await fixture.CreateDatabaseAsync();
+
+            db.Execute("create table \"foo\" (value int, primary key (value))");
+            db.Execute("create table \"baz\" (value int, foovalue int, constraint FK_Foo foreign key (foovalue) references \"foo\" (value))");
 
             for (int i = 0; i < 100; i++)
             {
-                _database.Execute("INSERT INTO \"foo\" VALUES (@0)", i);
-                _database.Execute("INSERT INTO \"baz\" VALUES (@0, @0)", i);
+                db.Execute("INSERT INTO \"foo\" VALUES (@0)", i);
+                db.Execute("INSERT INTO \"baz\" VALUES (@0, @0)", i);
             }
 
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM \"foo\"").ShouldBe(100);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM \"baz\"").ShouldBe(100);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM \"foo\"").ShouldBe(100);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM \"baz\"").ShouldBe(100);
 
-            var respawner = await Respawner.CreateAsync(_connection, new RespawnerOptions
+            var respawner = await Respawner.CreateAsync(db.Connection, new RespawnerOptions
             {
-                SchemasToInclude = new[] { _createdUser },
+                SchemasToInclude = new[] { fixture.User },
             });
             try
             {
-                await respawner.ResetAsync(_connection);
+                await respawner.ResetAsync(db.Connection);
             }
             catch
             {
-                _output.WriteLine(respawner.DeleteSql ?? string.Empty);
+                output.WriteLine(respawner.DeleteSql ?? string.Empty);
                 throw;
             }
 
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM \"foo\"").ShouldBe(0);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM \"baz\"").ShouldBe(0);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM \"foo\"").ShouldBe(0);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM \"baz\"").ShouldBe(0);
         }
 
         [SkipOnCI]
         public async Task ShouldHandleRelationshipsWithTableNames()
         {
-            _database.Execute("create table \"foo\" (value int, primary key (value))");
-            _database.Execute("create table \"baz\" (value int, foovalue int, constraint FK_Foo foreign key (foovalue) references \"foo\" (value))");
+            using var db = await fixture.CreateDatabaseAsync();
+
+            db.Execute("create table \"foo\" (value int, primary key (value))");
+            db.Execute("create table \"baz\" (value int, foovalue int, constraint FK_Foo foreign key (foovalue) references \"foo\" (value))");
 
             for (int i = 0; i < 100; i++)
             {
-                _database.Execute("INSERT INTO \"foo\" VALUES (@0)", i);
-                _database.Execute("INSERT INTO \"baz\" VALUES (@0, @0)", i);
+                db.Execute("INSERT INTO \"foo\" VALUES (@0)", i);
+                db.Execute("INSERT INTO \"baz\" VALUES (@0, @0)", i);
             }
 
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM \"foo\"").ShouldBe(100);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM \"baz\"").ShouldBe(100);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM \"foo\"").ShouldBe(100);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM \"baz\"").ShouldBe(100);
 
-            var respawner = await Respawner.CreateAsync(_connection, new RespawnerOptions
+            var createdUser = fixture.User;
+            var respawner = await Respawner.CreateAsync(db.Connection, new RespawnerOptions
             {
-                SchemasToInclude = new[] { _createdUser },
-                TablesToInclude = new[] { new Table(_createdUser, "foo"), new Table(_createdUser, "baz") },
-                TablesToIgnore = new[] { new Table(_createdUser, "bar") }
+                SchemasToInclude = new[] { createdUser },
+                TablesToInclude = new[] { new Table(createdUser, "foo"), new Table(createdUser, "baz") },
+                TablesToIgnore = new[] { new Table(createdUser, "bar") }
             });
             try
             {
-                await respawner.ResetAsync(_connection);
+                await respawner.ResetAsync(db.Connection);
             }
             catch
             {
-                _output.WriteLine(respawner.DeleteSql ?? string.Empty);
+                output.WriteLine(respawner.DeleteSql ?? string.Empty);
                 throw;
             }
 
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM \"foo\"").ShouldBe(0);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM \"baz\"").ShouldBe(0);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM \"foo\"").ShouldBe(0);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM \"baz\"").ShouldBe(0);
         }
 
         [SkipOnCI]
         public async Task ShouldHandleRelationshipsWithNamedPrimaryKeyConstraint()
         {
+            using var db = await fixture.CreateDatabaseAsync();
+
             var userA = Guid.NewGuid().ToString().Substring(0, 8);
             var userB = Guid.NewGuid().ToString().Substring(0, 8);
-            await CreateUser(userA);
-            await CreateUser(userB);
-            await _database.ExecuteAsync($"create table \"{userA}\".\"foo\" (value int, constraint PK_Foo primary key (value))");
-            await _database.ExecuteAsync($"create table \"{userA}\".\"baz\" (value int, foovalue int, constraint FK_Foo foreign key (foovalue) references \"{userA}\".\"foo\" (value))");
-            await _database.ExecuteAsync($"create table \"{userB}\".\"foo\" (value int, constraint PK_Foo primary key (value))");
-            await _database.ExecuteAsync($"create table \"{userB}\".\"baz\" (value int, foovalue int, constraint FK_Foo foreign key (foovalue) references \"{userB}\".\"foo\" (value))");
+            await CreateUser(db, userA);
+            await CreateUser(db, userB);
+            await db.ExecuteAsync($"create table \"{userA}\".\"foo\" (value int, constraint PK_Foo primary key (value))");
+            await db.ExecuteAsync($"create table \"{userA}\".\"baz\" (value int, foovalue int, constraint FK_Foo foreign key (foovalue) references \"{userA}\".\"foo\" (value))");
+            await db.ExecuteAsync($"create table \"{userB}\".\"foo\" (value int, constraint PK_Foo primary key (value))");
+            await db.ExecuteAsync($"create table \"{userB}\".\"baz\" (value int, foovalue int, constraint FK_Foo foreign key (foovalue) references \"{userB}\".\"foo\" (value))");
 
             for (int i = 0; i < 100; i++)
             {
-                await _database.ExecuteAsync($"INSERT INTO \"{userA}\".\"foo\" VALUES (@0)", i);
-                await _database.ExecuteAsync($"INSERT INTO \"{userA}\".\"baz\" VALUES (@0, @0)", i);
-                await _database.ExecuteAsync($"INSERT INTO \"{userB}\".\"foo\" VALUES (@0)", i);
-                await _database.ExecuteAsync($"INSERT INTO \"{userB}\".\"baz\" VALUES (@0, @0)", i);
+                await db.ExecuteAsync($"INSERT INTO \"{userA}\".\"foo\" VALUES (@0)", i);
+                await db.ExecuteAsync($"INSERT INTO \"{userA}\".\"baz\" VALUES (@0, @0)", i);
+                await db.ExecuteAsync($"INSERT INTO \"{userB}\".\"foo\" VALUES (@0)", i);
+                await db.ExecuteAsync($"INSERT INTO \"{userB}\".\"baz\" VALUES (@0, @0)", i);
             }
 
-            (await _database.ExecuteScalarAsync<int>($"SELECT COUNT(1) FROM \"{userA}\".\"foo\"")).ShouldBe(100);
-            (await _database.ExecuteScalarAsync<int>($"SELECT COUNT(1) FROM \"{userA}\".\"baz\"")).ShouldBe(100);
-            (await _database.ExecuteScalarAsync<int>($"SELECT COUNT(1) FROM \"{userB}\".\"foo\"")).ShouldBe(100);
-            (await _database.ExecuteScalarAsync<int>($"SELECT COUNT(1) FROM \"{userB}\".\"baz\"")).ShouldBe(100);
+            (await db.ExecuteScalarAsync<int>($"SELECT COUNT(1) FROM \"{userA}\".\"foo\"")).ShouldBe(100);
+            (await db.ExecuteScalarAsync<int>($"SELECT COUNT(1) FROM \"{userA}\".\"baz\"")).ShouldBe(100);
+            (await db.ExecuteScalarAsync<int>($"SELECT COUNT(1) FROM \"{userB}\".\"foo\"")).ShouldBe(100);
+            (await db.ExecuteScalarAsync<int>($"SELECT COUNT(1) FROM \"{userB}\".\"baz\"")).ShouldBe(100);
 
-            var respawner = await Respawner.CreateAsync(_connection, new RespawnerOptions
+            var respawner = await Respawner.CreateAsync(db.Connection, new RespawnerOptions
             {
                 SchemasToInclude = new[] { userA },
             });
             try
             {
-                await respawner.ResetAsync(_connection);
+                await respawner.ResetAsync(db.Connection);
             }
             catch
             {
-                _output.WriteLine(respawner.DeleteSql ?? string.Empty);
+                output.WriteLine(respawner.DeleteSql ?? string.Empty);
                 throw;
             }
 
-            (await _database.ExecuteScalarAsync<int>($"SELECT COUNT(1) FROM \"{userA}\".\"foo\"")).ShouldBe(0);
-            (await _database.ExecuteScalarAsync<int>($"SELECT COUNT(1) FROM \"{userA}\".\"baz\"")).ShouldBe(0);
-            (await _database.ExecuteScalarAsync<int>($"SELECT COUNT(1) FROM \"{userB}\".\"foo\"")).ShouldBe(100);
-            (await _database.ExecuteScalarAsync<int>($"SELECT COUNT(1) FROM \"{userB}\".\"baz\"")).ShouldBe(100);
-        
-            await DropUser(userA);
-            await DropUser(userB);
+            (await db.ExecuteScalarAsync<int>($"SELECT COUNT(1) FROM \"{userA}\".\"foo\"")).ShouldBe(0);
+            (await db.ExecuteScalarAsync<int>($"SELECT COUNT(1) FROM \"{userA}\".\"baz\"")).ShouldBe(0);
+            (await db.ExecuteScalarAsync<int>($"SELECT COUNT(1) FROM \"{userB}\".\"foo\"")).ShouldBe(100);
+            (await db.ExecuteScalarAsync<int>($"SELECT COUNT(1) FROM \"{userB}\".\"baz\"")).ShouldBe(100);
         }
 
         [SkipOnCI]
         public async Task ShouldHandleComplexCycles()
         {
-            _database.Execute("create table \"a\" (\"id\" int primary key, \"b_id\" int NULL)");
-            _database.Execute("create table \"b\" (\"id\" int primary key, \"a_id\" int NULL, \"c_id\" int NULL, \"d_id\" int NULL)");
-            _database.Execute("create table \"c\" (\"id\" int primary key, \"d_id\" int NULL)");
-            _database.Execute("create table \"d\" (\"id\" int primary key)");
-            _database.Execute("create table \"e\" (\"id\" int primary key, \"a_id\" int NULL)");
-            _database.Execute("create table \"f\" (\"id\" int primary key, \"b_id\" int NULL)");
-            _database.Execute("alter table \"a\" add constraint \"FK_a_b\" foreign key (\"b_id\") references \"b\" (\"id\")");
-            _database.Execute("alter table \"b\" add constraint \"FK_b_a\" foreign key (\"a_id\") references \"a\" (\"id\")");
-            _database.Execute("alter table \"b\" add constraint \"FK_b_c\" foreign key (\"c_id\") references \"c\" (\"id\")");
-            _database.Execute("alter table \"b\" add constraint \"FK_b_d\" foreign key (\"d_id\") references \"d\" (\"id\")");
-            _database.Execute("alter table \"c\" add constraint \"FK_c_d\" foreign key (\"d_id\") references \"d\" (\"id\")");
-            _database.Execute("alter table \"e\" add constraint \"FK_e_a\" foreign key (\"a_id\") references \"a\" (\"id\")");
-            _database.Execute("alter table \"f\" add constraint \"FK_f_b\" foreign key (\"b_id\") references \"b\" (\"id\")");
+            using var db = await fixture.CreateDatabaseAsync();
+
+            db.Execute("create table \"a\" (\"id\" int primary key, \"b_id\" int NULL)");
+            db.Execute("create table \"b\" (\"id\" int primary key, \"a_id\" int NULL, \"c_id\" int NULL, \"d_id\" int NULL)");
+            db.Execute("create table \"c\" (\"id\" int primary key, \"d_id\" int NULL)");
+            db.Execute("create table \"d\" (\"id\" int primary key)");
+            db.Execute("create table \"e\" (\"id\" int primary key, \"a_id\" int NULL)");
+            db.Execute("create table \"f\" (\"id\" int primary key, \"b_id\" int NULL)");
+            db.Execute("alter table \"a\" add constraint \"FK_a_b\" foreign key (\"b_id\") references \"b\" (\"id\")");
+            db.Execute("alter table \"b\" add constraint \"FK_b_a\" foreign key (\"a_id\") references \"a\" (\"id\")");
+            db.Execute("alter table \"b\" add constraint \"FK_b_c\" foreign key (\"c_id\") references \"c\" (\"id\")");
+            db.Execute("alter table \"b\" add constraint \"FK_b_d\" foreign key (\"d_id\") references \"d\" (\"id\")");
+            db.Execute("alter table \"c\" add constraint \"FK_c_d\" foreign key (\"d_id\") references \"d\" (\"id\")");
+            db.Execute("alter table \"e\" add constraint \"FK_e_a\" foreign key (\"a_id\") references \"a\" (\"id\")");
+            db.Execute("alter table \"f\" add constraint \"FK_f_b\" foreign key (\"b_id\") references \"b\" (\"id\")");
 
 
-            _database.Execute("insert into \"d\" (\"id\") values (1)");
-            _database.Execute("insert into \"c\" (\"id\", \"d_id\") values (1, 1)");
-            _database.Execute("insert into \"a\" (\"id\") values (1)");
-            _database.Execute("insert into \"b\" (\"id\", \"c_id\", \"d_id\") values (1, 1, 1)");
-            _database.Execute("insert into \"e\" (\"id\", \"a_id\") values (1, 1)");
-            _database.Execute("insert into \"f\" (\"id\", \"b_id\") values (1, 1)");
-            _database.Execute("update \"a\" set \"b_id\" = 1");
-            _database.Execute("update \"b\" set \"a_id\" = 1");
+            db.Execute("insert into \"d\" (\"id\") values (1)");
+            db.Execute("insert into \"c\" (\"id\", \"d_id\") values (1, 1)");
+            db.Execute("insert into \"a\" (\"id\") values (1)");
+            db.Execute("insert into \"b\" (\"id\", \"c_id\", \"d_id\") values (1, 1, 1)");
+            db.Execute("insert into \"e\" (\"id\", \"a_id\") values (1, 1)");
+            db.Execute("insert into \"f\" (\"id\", \"b_id\") values (1, 1)");
+            db.Execute("update \"a\" set \"b_id\" = 1");
+            db.Execute("update \"b\" set \"a_id\" = 1");
 
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM \"a\"").ShouldBe(1);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM \"b\"").ShouldBe(1);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM \"c\"").ShouldBe(1);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM \"d\"").ShouldBe(1);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM \"e\"").ShouldBe(1);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM \"f\"").ShouldBe(1);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM \"a\"").ShouldBe(1);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM \"b\"").ShouldBe(1);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM \"c\"").ShouldBe(1);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM \"d\"").ShouldBe(1);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM \"e\"").ShouldBe(1);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM \"f\"").ShouldBe(1);
 
-            var respawner = await Respawner.CreateAsync(_connection, new RespawnerOptions
+            var respawner = await Respawner.CreateAsync(db.Connection, new RespawnerOptions
             {
-                SchemasToInclude = new[] { _createdUser },
+                SchemasToInclude = new[] { fixture.User },
             });
             try
             {
-                await respawner.ResetAsync(_connection);
+                await respawner.ResetAsync(db.Connection);
             }
             catch
             {
-                _output.WriteLine(respawner.DeleteSql ?? string.Empty);
+                output.WriteLine(respawner.DeleteSql ?? string.Empty);
                 throw;
             }
 
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM \"a\"").ShouldBe(0);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM \"b\"").ShouldBe(0);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM \"c\"").ShouldBe(0);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM \"d\"").ShouldBe(0);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM \"e\"").ShouldBe(0);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM \"f\"").ShouldBe(0);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM \"a\"").ShouldBe(0);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM \"b\"").ShouldBe(0);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM \"c\"").ShouldBe(0);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM \"d\"").ShouldBe(0);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM \"e\"").ShouldBe(0);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM \"f\"").ShouldBe(0);
         }
 
         [SkipOnCI]
         public async Task ShouldHandleCircularRelationships()
         {
-            _database.Execute("create table \"parent\" (id int primary key, childid int NULL)");
-            _database.Execute("create table \"child\" (id int primary key, parentid int NULL)");
-            _database.Execute("alter table \"parent\" add constraint FK_Child foreign key (ChildId) references \"child\" (Id)");
-            _database.Execute("alter table \"child\" add constraint FK_Parent foreign key (ParentId) references \"parent\" (Id)");
+            using var db = await fixture.CreateDatabaseAsync();
+
+            db.Execute("create table \"parent\" (id int primary key, childid int NULL)");
+            db.Execute("create table \"child\" (id int primary key, parentid int NULL)");
+            db.Execute("alter table \"parent\" add constraint FK_Child foreign key (ChildId) references \"child\" (Id)");
+            db.Execute("alter table \"child\" add constraint FK_Parent foreign key (ParentId) references \"parent\" (Id)");
 
             for (int i = 0; i < 100; i++)
             {
-                _database.Execute("INSERT INTO \"parent\" VALUES (@0, null)", i);
-                _database.Execute("INSERT INTO \"child\" VALUES (@0, null)", i);
+                db.Execute("INSERT INTO \"parent\" VALUES (@0, null)", i);
+                db.Execute("INSERT INTO \"child\" VALUES (@0, null)", i);
             }
 
-            _database.Execute("update \"parent\" set childid = 0");
-            _database.Execute("update \"child\" set parentid = 1");
+            db.Execute("update \"parent\" set childid = 0");
+            db.Execute("update \"child\" set parentid = 1");
 
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM \"parent\"").ShouldBe(100);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM \"child\"").ShouldBe(100);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM \"parent\"").ShouldBe(100);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM \"child\"").ShouldBe(100);
 
-            var respawner = await Respawner.CreateAsync(_connection, new RespawnerOptions
+            var respawner = await Respawner.CreateAsync(db.Connection, new RespawnerOptions
             {
-                SchemasToInclude = new[] { _createdUser },
+                SchemasToInclude = new[] { fixture.User },
             });
             try
             {
-                await respawner.ResetAsync(_connection);
+                await respawner.ResetAsync(db.Connection);
             }
             catch
             {
-                _output.WriteLine(respawner.DeleteSql ?? string.Empty);
+                output.WriteLine(respawner.DeleteSql ?? string.Empty);
                 throw;
             }
 
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM \"parent\"").ShouldBe(0);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM \"child\"").ShouldBe(0);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM \"parent\"").ShouldBe(0);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM \"child\"").ShouldBe(0);
         }
 
         [SkipOnCI]
         public async Task ShouldIgnoreTables()
         {
-            await _database.ExecuteAsync("create table \"foo\" (value int)");
-            await _database.ExecuteAsync("create table \"bar\" (value int)");
+            using var db = await fixture.CreateDatabaseAsync();
+
+            await db.ExecuteAsync("create table \"foo\" (value int)");
+            await db.ExecuteAsync("create table \"bar\" (value int)");
 
             for (int i = 0; i < 100; i++)
             {
-                await _database.ExecuteAsync("INSERT INTO \"foo\" VALUES (@0)", i);
-                await _database.ExecuteAsync("INSERT INTO \"bar\" VALUES (@0)", i);
+                await db.ExecuteAsync("INSERT INTO \"foo\" VALUES (@0)", i);
+                await db.ExecuteAsync("INSERT INTO \"bar\" VALUES (@0)", i);
             }
 
-            var respawner = await Respawner.CreateAsync(_connection, new RespawnerOptions
+            var respawner = await Respawner.CreateAsync(db.Connection, new RespawnerOptions
             {
-                SchemasToInclude = new[] { _createdUser },
+                SchemasToInclude = new[] { fixture.User },
                 TablesToIgnore = new[] { new Table("foo") }
             });
-            await respawner.ResetAsync(_connection);
+            await respawner.ResetAsync(db.Connection);
 
-            (await _database.ExecuteScalarAsync<int>("SELECT COUNT(1) FROM \"foo\"")).ShouldBe(100);
-            (await _database.ExecuteScalarAsync<int>("SELECT COUNT(1) FROM \"bar\"")).ShouldBe(0);
+            (await db.ExecuteScalarAsync<int>("SELECT COUNT(1) FROM \"foo\"")).ShouldBe(100);
+            (await db.ExecuteScalarAsync<int>("SELECT COUNT(1) FROM \"bar\"")).ShouldBe(0);
         }
 
         [SkipOnCI]
         public async Task ShouldIgnoreTablesWithSchema()
         {
-            await _database.ExecuteAsync("create table \"foo\" (value int)");
-            await _database.ExecuteAsync("create table \"bar\" (value int)");
+            using var db = await fixture.CreateDatabaseAsync();
+
+            await db.ExecuteAsync("create table \"foo\" (value int)");
+            await db.ExecuteAsync("create table \"bar\" (value int)");
 
             for (int i = 0; i < 100; i++)
             {
-                await _database.ExecuteAsync("INSERT INTO \"foo\" VALUES (@0)", i);
-                await _database.ExecuteAsync("INSERT INTO \"bar\" VALUES (@0)", i);
+                await db.ExecuteAsync("INSERT INTO \"foo\" VALUES (@0)", i);
+                await db.ExecuteAsync("INSERT INTO \"bar\" VALUES (@0)", i);
             }
 
-            var respawner = await Respawner.CreateAsync(_connection, new RespawnerOptions
+            var createdUser = fixture.User;
+            var respawner = await Respawner.CreateAsync(db.Connection, new RespawnerOptions
             {
-                SchemasToInclude = new[] { _createdUser },
-                TablesToIgnore = new[] { new Table(_createdUser, "foo") }
+                SchemasToInclude = new[] { createdUser },
+                TablesToIgnore = new[] { new Table(createdUser, "foo") }
             });
-            await respawner.ResetAsync(_connection);
+            await respawner.ResetAsync(db.Connection);
 
-            (await _database.ExecuteScalarAsync<int>("SELECT COUNT(1) FROM \"foo\"")).ShouldBe(100);
-            (await _database.ExecuteScalarAsync<int>("SELECT COUNT(1) FROM \"bar\"")).ShouldBe(0);
+            (await db.ExecuteScalarAsync<int>("SELECT COUNT(1) FROM \"foo\"")).ShouldBe(100);
+            (await db.ExecuteScalarAsync<int>("SELECT COUNT(1) FROM \"bar\"")).ShouldBe(0);
         }
 
         [SkipOnCI]
         public async Task ShouldIncludeTables()
         {
-            await _database.ExecuteAsync("create table \"foo\" (value int)");
-            await _database.ExecuteAsync("create table \"bar\" (value int)");
+            using var db = await fixture.CreateDatabaseAsync();
+
+            await db.ExecuteAsync("create table \"foo\" (value int)");
+            await db.ExecuteAsync("create table \"bar\" (value int)");
 
             for (int i = 0; i < 100; i++)
             {
-                await _database.ExecuteAsync("INSERT INTO \"foo\" VALUES (@0)", i);
-                await _database.ExecuteAsync("INSERT INTO \"bar\" VALUES (@0)", i);
+                await db.ExecuteAsync("INSERT INTO \"foo\" VALUES (@0)", i);
+                await db.ExecuteAsync("INSERT INTO \"bar\" VALUES (@0)", i);
             }
 
-            var respawner = await Respawner.CreateAsync(_connection, new RespawnerOptions
+            var respawner = await Respawner.CreateAsync(db.Connection, new RespawnerOptions
             {
-                SchemasToInclude = new[] { _createdUser },
+                SchemasToInclude = new[] { fixture.User },
                 TablesToInclude = new[] { new Table("foo") }
             });
-            await respawner.ResetAsync(_connection);
+            await respawner.ResetAsync(db.Connection);
 
-            (await _database.ExecuteScalarAsync<int>("SELECT COUNT(1) FROM \"foo\"")).ShouldBe(0);
-            (await _database.ExecuteScalarAsync<int>("SELECT COUNT(1) FROM \"bar\"")).ShouldBe(100);
+            (await db.ExecuteScalarAsync<int>("SELECT COUNT(1) FROM \"foo\"")).ShouldBe(0);
+            (await db.ExecuteScalarAsync<int>("SELECT COUNT(1) FROM \"bar\"")).ShouldBe(100);
         }
 
         [SkipOnCI]
         public async Task ShouldIncludeTablesWithSchema()
         {
-            await _database.ExecuteAsync("create table \"foo\" (value int)");
-            await _database.ExecuteAsync("create table \"bar\" (value int)");
+            using var db = await fixture.CreateDatabaseAsync();
+
+            await db.ExecuteAsync("create table \"foo\" (value int)");
+            await db.ExecuteAsync("create table \"bar\" (value int)");
 
             for (int i = 0; i < 100; i++)
             {
-                await _database.ExecuteAsync("INSERT INTO \"foo\" VALUES (@0)", i);
-                await _database.ExecuteAsync("INSERT INTO \"bar\" VALUES (@0)", i);
+                await db.ExecuteAsync("INSERT INTO \"foo\" VALUES (@0)", i);
+                await db.ExecuteAsync("INSERT INTO \"bar\" VALUES (@0)", i);
             }
 
-            var respawner = await Respawner.CreateAsync(_connection, new RespawnerOptions
+            var respawner = await Respawner.CreateAsync(db.Connection, new RespawnerOptions
             {
-                TablesToInclude = new[] { new Table(_createdUser, "foo") }
+                TablesToInclude = new[] { new Table(fixture.User, "foo") }
             });
-            await respawner.ResetAsync(_connection);
+            await respawner.ResetAsync(db.Connection);
 
-            (await _database.ExecuteScalarAsync<int>("SELECT COUNT(1) FROM \"foo\"")).ShouldBe(0);
-            (await _database.ExecuteScalarAsync<int>("SELECT COUNT(1) FROM \"bar\"")).ShouldBe(100);
+            (await db.ExecuteScalarAsync<int>("SELECT COUNT(1) FROM \"foo\"")).ShouldBe(0);
+            (await db.ExecuteScalarAsync<int>("SELECT COUNT(1) FROM \"bar\"")).ShouldBe(100);
         }
 
         [SkipOnCI]
         public async Task ShouldExcludeSchemas()
         {
+            using var db = await fixture.CreateDatabaseAsync();
+
             var userA = Guid.NewGuid().ToString().Substring(0, 8);
             var userB = Guid.NewGuid().ToString().Substring(0, 8);
-            await CreateUser(userA);
-            await CreateUser(userB);
-            await _database.ExecuteAsync("create table \"" + userA + "\".\"foo\" (value int)");
-            await _database.ExecuteAsync("create table \"" + userB + "\".\"bar\" (value int)");
+            await CreateUser(db, userA);
+            await CreateUser(db, userB);
+            await db.ExecuteAsync("create table \"" + userA + "\".\"foo\" (value int)");
+            await db.ExecuteAsync("create table \"" + userB + "\".\"bar\" (value int)");
 
             for (int i = 0; i < 100; i++)
             {
-                await _database.ExecuteAsync("INSERT INTO \"" + userA + "\".\"foo\" VALUES (" + i + ")");
-                await _database.ExecuteAsync("INSERT INTO \"" + userB + "\".\"bar\" VALUES (" + i + ")");
+                await db.ExecuteAsync("INSERT INTO \"" + userA + "\".\"foo\" VALUES (" + i + ")");
+                await db.ExecuteAsync("INSERT INTO \"" + userB + "\".\"bar\" VALUES (" + i + ")");
             }
 
-            var respawner = await Respawner.CreateAsync(_connection, new RespawnerOptions
+            var respawner = await Respawner.CreateAsync(db.Connection, new RespawnerOptions
             {
                 // We must make sure we don't delete all these users that are used by Oracle
                 SchemasToExclude = new[]
@@ -446,94 +412,45 @@ namespace Respawn.DatabaseTests
                     "LBACSYS", "APEX_040200", "DVSYS", "AUDSYS", "OLAPSYS", "SCOTT"
                 }
             });
-            await respawner.ResetAsync(_connection);
+            await respawner.ResetAsync(db.Connection);
 
-            (await _database.ExecuteScalarAsync<int>("SELECT COUNT(1) FROM \"" + userA + "\".\"foo\"")).ShouldBe(100);
-            (await _database.ExecuteScalarAsync<int>("SELECT COUNT(1) FROM \"" + userB + "\".\"bar\"")).ShouldBe(0);
-
-            // Clean up before leaving
-            await DropUser(userA);
-            await DropUser(userB);
+            (await db.ExecuteScalarAsync<int>("SELECT COUNT(1) FROM \"" + userA + "\".\"foo\"")).ShouldBe(100);
+            (await db.ExecuteScalarAsync<int>("SELECT COUNT(1) FROM \"" + userB + "\".\"bar\"")).ShouldBe(0);
         }
 
         [SkipOnCI]
         public async Task ShouldIncludeSchemas()
         {
+            using var db = await fixture.CreateDatabaseAsync();
+
             var userA = Guid.NewGuid().ToString().Substring(0, 8);
             var userB = Guid.NewGuid().ToString().Substring(0, 8);
-            await CreateUser(userA);
-            await CreateUser(userB);
-            await _database.ExecuteAsync("create table \"" + userA + "\".\"foo\" (value int)");
-            await _database.ExecuteAsync("create table \"" + userB + "\".\"bar\" (value int)");
+            await CreateUser(db, userA);
+            await CreateUser(db, userB);
+            await db.ExecuteAsync("create table \"" + userA + "\".\"foo\" (value int)");
+            await db.ExecuteAsync("create table \"" + userB + "\".\"bar\" (value int)");
 
             for (int i = 0; i < 100; i++)
             {
-                await _database.ExecuteAsync("INSERT INTO \"" + userA + "\".\"foo\" VALUES (" + i + ")");
-                await _database.ExecuteAsync("INSERT INTO \"" + userB + "\".\"bar\" VALUES (" + i + ")");
+                await db.ExecuteAsync("INSERT INTO \"" + userA + "\".\"foo\" VALUES (" + i + ")");
+                await db.ExecuteAsync("INSERT INTO \"" + userB + "\".\"bar\" VALUES (" + i + ")");
             }
 
-            var respawner = await Respawner.CreateAsync(_connection, new RespawnerOptions
+            var respawner = await Respawner.CreateAsync(db.Connection, new RespawnerOptions
             {
                 SchemasToInclude = new[] { userB }
             });
-            await respawner.ResetAsync(_connection);
+            await respawner.ResetAsync(db.Connection);
 
-            (await _database.ExecuteScalarAsync<int>("SELECT COUNT(1) FROM \"" + userA + "\".\"foo\"")).ShouldBe(100);
-            (await _database.ExecuteScalarAsync<int>("SELECT COUNT(1) FROM \"" + userB + "\".\"bar\"")).ShouldBe(0);
-
-            // Clean up before leaving
-            await DropUser(userA);
-            await DropUser(userB);
+            (await db.ExecuteScalarAsync<int>("SELECT COUNT(1) FROM \"" + userA + "\".\"foo\"")).ShouldBe(100);
+            (await db.ExecuteScalarAsync<int>("SELECT COUNT(1) FROM \"" + userB + "\".\"bar\"")).ShouldBe(0);
         }
 
-        private async Task CreateUser(string userName)
+        private static async Task CreateUser(IDatabase db, string userName)
         {
-            var connString = _sqlContainer.GetConnectionString();
-            using (var connection = new OracleConnection(connString))
-            {
-                await connection.OpenAsync();
-
-                using (var cmd = connection.CreateCommand())
-                {
-                    cmd.CommandText = "create user \"" + userName + "\" IDENTIFIED BY 123456";
-                    await cmd.ExecuteNonQueryAsync();
-                    // We need some permissions in order to execute all the test queries
-                    cmd.CommandText = "alter user \"" + userName + "\" IDENTIFIED BY 123456 account unlock";
-                    await cmd.ExecuteNonQueryAsync();
-                    cmd.CommandText = "grant all privileges to \"" + userName + "\" IDENTIFIED BY 123456";
-                    await cmd.ExecuteNonQueryAsync();
-                }
-            }
+            await db.ExecuteAsync($"""create user "{userName}" IDENTIFIED BY 123456""");
+            await db.ExecuteAsync($"""alter user "{userName}" IDENTIFIED BY 123456 account unlock""");
+            await db.ExecuteAsync($"""grant all privileges to "{userName}" IDENTIFIED BY 123456""");
         }
-
-        private async Task DropUser(string userName)
-        {
-            var connString = _sqlContainer.GetConnectionString();
-            using (var connection = new OracleConnection(connString))
-            {
-                await connection.OpenAsync();
-
-                using (var cmd = connection.CreateCommand())
-                {
-                    // First we need to disconnect the user
-                    cmd.CommandText = @"SELECT s.sid, s.serial#, s.status, p.spid FROM v$session s, v$process p WHERE s.username = '" + userName + "' AND p.addr(+) = s.paddr";
-
-                    var dataReader = cmd.ExecuteReader();
-                    if (await dataReader.ReadAsync())
-                    {
-                        var sid = dataReader.GetOracleDecimal(0);
-                        var serial = dataReader.GetOracleDecimal(1);
-
-                        cmd.CommandText = "ALTER SYSTEM KILL SESSION '" + sid + ", " + serial + "'";
-                        await cmd.ExecuteNonQueryAsync();
-                    }
-
-                    cmd.CommandText = "drop user \"" + userName + "\" CASCADE";
-                    await cmd.ExecuteNonQueryAsync();
-                }
-            }
-        }
-
     }
 }
-#endif

--- a/Respawn.DatabaseTests/OracleTests.cs
+++ b/Respawn.DatabaseTests/OracleTests.cs
@@ -39,8 +39,7 @@ namespace Respawn.DatabaseTests
             _createdUser = Guid.NewGuid().ToString().Substring(0, 8);
 
             
-            _sqlContainer = new OracleBuilder()
-                .WithImage("gvenzl/oracle-xe:21.3.0-slim-faststart")
+            _sqlContainer = new OracleBuilder("gvenzl/oracle-free:23-slim-faststart")
                 .WithUsername(_createdUser)
                 .Build();
             await _sqlContainer.StartAsync();

--- a/Respawn.DatabaseTests/PostgresFixture.cs
+++ b/Respawn.DatabaseTests/PostgresFixture.cs
@@ -1,0 +1,18 @@
+using System.Data.Common;
+using Npgsql;
+using NPoco;
+using Testcontainers.PostgreSql;
+using Xunit.Abstractions;
+
+namespace Respawn.DatabaseTests;
+
+public class PostgresFixture(IMessageSink messageSink) : DbFixture<PostgreSqlBuilder, PostgreSqlContainer>(messageSink)
+{
+    public override DbProviderFactory DbProviderFactory => NpgsqlFactory.Instance;
+
+    protected override DatabaseType DbType => DatabaseType.PostgreSQL;
+
+    protected override PostgreSqlBuilder CreateBuilder() => new("postgres:16");
+
+    public override string ConnectionString => new NpgsqlConnectionStringBuilder(base.ConnectionString) { IncludeErrorDetail = true }.ConnectionString;
+}

--- a/Respawn.DatabaseTests/PostgresTests.cs
+++ b/Respawn.DatabaseTests/PostgresTests.cs
@@ -1,395 +1,360 @@
-﻿using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Respawn.Graph;
-using Testcontainers.PostgreSql;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace Respawn.DatabaseTests
 {
-    using System;
-    using Npgsql;
-    using NPoco;
     using Shouldly;
 
-    public class PostgresTests : IAsyncLifetime
+    public class PostgresTests(ITestOutputHelper output, PostgresFixture fixture) : IClassFixture<PostgresFixture>
     {
-        private readonly ITestOutputHelper _output;
-        private NpgsqlConnection _connection;
-        private Database _database;
-        private PostgreSqlContainer _sqlContainer;
-
-        public PostgresTests(ITestOutputHelper output) => _output = output;
-
-        public async Task InitializeAsync()
-        {
-            // var rootConnString = "Server=127.0.0.1;Port=8081;User ID=docker;Password=Password12!;database=postgres";
-            // var dbConnString = "Server=127.0.0.1;Port=8081;User ID=docker;Password=Password12!;database={0}";
-            // if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("CI")))
-            // {
-            //     rootConnString = "Server=127.0.0.1;Port=5432;User ID=postgres;Password=root;database=postgres";
-            //     dbConnString = "Server=127.0.0.1;Port=5432;User ID=postgres;Password=root;database={0}";
-            // }
-            // var dbName = DateTime.Now.ToString("yyyyMMddHHmmss") + Guid.NewGuid().ToString("N");
-            // await using (var connection = new NpgsqlConnection(rootConnString))
-            // {
-            //     connection.Open();
-            //
-            //     await using (var cmd = connection.CreateCommand())
-            //     {
-            //         cmd.CommandText = "create database \"" + dbName + "\"";
-            //         await cmd.ExecuteNonQueryAsync();
-            //     }
-            // }
-            
-            var dbName = DateTime.Now.ToString("yyyyMMddHHmmss") + Guid.NewGuid().ToString("N");
-            
-            _sqlContainer = new PostgreSqlBuilder()
-                .WithImage("postgres:16")
-                .WithDatabase(dbName)
-                .Build();
-
-            await _sqlContainer.StartAsync();
-            
-            var dbConnString = _sqlContainer.GetConnectionString();
-            
-            _connection = new NpgsqlConnection(dbConnString);
-            _connection.Open();
-
-            _database = new Database(_connection, DatabaseType.PostgreSQL);
-        }
-
-        public async Task DisposeAsync()
-        {
-            _connection?.Close();
-            _connection?.Dispose();
-            _connection = null;
-            await _sqlContainer.StopAsync();
-            await _sqlContainer.DisposeAsync();
-        }
-
         [Fact]
         public async Task ShouldDeleteData()
         {
-            await _database.ExecuteAsync("create table \"foo\" (value int)");
+            using var db = await fixture.CreateDatabaseAsync();
+
+            await db.ExecuteAsync("create table \"foo\" (value int)");
 
             for (int i = 0; i < 100; i++)
             {
-                await _database.ExecuteAsync("INSERT INTO \"foo\" VALUES (@0)", i);
+                await db.ExecuteAsync("INSERT INTO \"foo\" VALUES (@0)", i);
             }
 
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM \"foo\"").ShouldBe(100);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM \"foo\"").ShouldBe(100);
 
-            var checkpoint = await Respawner.CreateAsync(_connection);
-            await checkpoint.ResetAsync(_connection);
+            var checkpoint = await Respawner.CreateAsync(db.Connection);
+            await checkpoint.ResetAsync(db.Connection);
 
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM \"foo\"").ShouldBe(0);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM \"foo\"").ShouldBe(0);
         }
 
         [Fact]
         public async Task ShouldIgnoreTables()
         {
-            await _database.ExecuteAsync("create table foo (Value int)");
-            await _database.ExecuteAsync("create table bar (Value int)");
+            using var db = await fixture.CreateDatabaseAsync();
+
+            await db.ExecuteAsync("create table foo (Value int)");
+            await db.ExecuteAsync("create table bar (Value int)");
 
             for (int i = 0; i < 100; i++)
             {
-                await _database.ExecuteAsync("INSERT INTO \"foo\" VALUES (@0)", i);
-                await _database.ExecuteAsync("INSERT INTO \"bar\" VALUES (@0)", i);
+                await db.ExecuteAsync("INSERT INTO \"foo\" VALUES (@0)", i);
+                await db.ExecuteAsync("INSERT INTO \"bar\" VALUES (@0)", i);
             }
 
-            var checkpoint = await Respawner.CreateAsync(_connection, new RespawnerOptions
+            var checkpoint = await Respawner.CreateAsync(db.Connection, new RespawnerOptions
             {
                 TablesToIgnore = new Table[] { "foo" }
             });
-            await checkpoint.ResetAsync(_connection);
+            await checkpoint.ResetAsync(db.Connection);
 
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM foo").ShouldBe(100);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM bar").ShouldBe(0);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM foo").ShouldBe(100);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM bar").ShouldBe(0);
         }
 
         [Fact]
         public async Task ShouldIgnoreTablesIfSchemaSpecified()
         {
-            await _database.ExecuteAsync("create schema eggs");
-            await _database.ExecuteAsync("create table eggs.foo (Value int)");
-            await _database.ExecuteAsync("create table eggs.bar (Value int)");
+            using var db = await fixture.CreateDatabaseAsync();
+
+            await db.ExecuteAsync("create schema eggs");
+            await db.ExecuteAsync("create table eggs.foo (Value int)");
+            await db.ExecuteAsync("create table eggs.bar (Value int)");
 
             for (int i = 0; i < 100; i++)
             {
-                await _database.ExecuteAsync("INSERT INTO \"eggs\".\"foo\" VALUES (@0)", i);
-                await _database.ExecuteAsync("INSERT INTO \"eggs\".\"bar\" VALUES (@0)", i);
+                await db.ExecuteAsync("INSERT INTO \"eggs\".\"foo\" VALUES (@0)", i);
+                await db.ExecuteAsync("INSERT INTO \"eggs\".\"bar\" VALUES (@0)", i);
             }
 
-            var checkpoint = await Respawner.CreateAsync(_connection, new RespawnerOptions
+            var checkpoint = await Respawner.CreateAsync(db.Connection, new RespawnerOptions
             {
                 TablesToIgnore = new Table[] { new Table("eggs", "foo") }
             });
-            await checkpoint.ResetAsync(_connection);
+            await checkpoint.ResetAsync(db.Connection);
 
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM eggs.foo").ShouldBe(100);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM eggs.bar").ShouldBe(0);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM eggs.foo").ShouldBe(100);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM eggs.bar").ShouldBe(0);
         }
 
         [Fact]
         public async Task ShouldIncludeTables()
         {
-            await _database.ExecuteAsync("create table foo (Value int)");
-            await _database.ExecuteAsync("create table bar (Value int)");
+            using var db = await fixture.CreateDatabaseAsync();
+
+            await db.ExecuteAsync("create table foo (Value int)");
+            await db.ExecuteAsync("create table bar (Value int)");
 
             for (int i = 0; i < 100; i++)
             {
-                await _database.ExecuteAsync("INSERT INTO \"foo\" VALUES (@0)", i);
-                await _database.ExecuteAsync("INSERT INTO \"bar\" VALUES (@0)", i);
+                await db.ExecuteAsync("INSERT INTO \"foo\" VALUES (@0)", i);
+                await db.ExecuteAsync("INSERT INTO \"bar\" VALUES (@0)", i);
             }
 
-            var checkpoint = await Respawner.CreateAsync(_connection, new RespawnerOptions
+            var checkpoint = await Respawner.CreateAsync(db.Connection, new RespawnerOptions
             {
                 TablesToInclude = new Table[] { "foo" }
             });
-            await checkpoint.ResetAsync(_connection);
+            await checkpoint.ResetAsync(db.Connection);
 
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM foo").ShouldBe(0);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM bar").ShouldBe(100);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM foo").ShouldBe(0);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM bar").ShouldBe(100);
         }
 
         [Fact]
         public async Task ShouldIncludeTablesIfSchemaSpecified()
         {
-            await _database.ExecuteAsync("create schema eggs");
-            await _database.ExecuteAsync("create table eggs.foo (Value int)");
-            await _database.ExecuteAsync("create table eggs.bar (Value int)");
+            using var db = await fixture.CreateDatabaseAsync();
+
+            await db.ExecuteAsync("create schema eggs");
+            await db.ExecuteAsync("create table eggs.foo (Value int)");
+            await db.ExecuteAsync("create table eggs.bar (Value int)");
 
             for (int i = 0; i < 100; i++)
             {
-                await _database.ExecuteAsync("INSERT INTO \"eggs\".\"foo\" VALUES (@0)", i);
-                await _database.ExecuteAsync("INSERT INTO \"eggs\".\"bar\" VALUES (@0)", i);
+                await db.ExecuteAsync("INSERT INTO \"eggs\".\"foo\" VALUES (@0)", i);
+                await db.ExecuteAsync("INSERT INTO \"eggs\".\"bar\" VALUES (@0)", i);
             }
 
-            var checkpoint = await Respawner.CreateAsync(_connection, new RespawnerOptions
+            var checkpoint = await Respawner.CreateAsync(db.Connection, new RespawnerOptions
             {
                 TablesToInclude = new Table[] { new Table("eggs", "foo") }
             });
-            await checkpoint.ResetAsync(_connection);
+            await checkpoint.ResetAsync(db.Connection);
 
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM eggs.foo").ShouldBe(0);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM eggs.bar").ShouldBe(100);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM eggs.foo").ShouldBe(0);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM eggs.bar").ShouldBe(100);
         }
 
         [Fact]
         public async Task ShouldHandleRelationships()
         {
-            await _database.ExecuteAsync("create table foo (value int, primary key (value))");
-            await _database.ExecuteAsync("create table baz (value int, foovalue int, constraint FK_Foo foreign key (foovalue) references foo (value))");
+            using var db = await fixture.CreateDatabaseAsync();
+
+            await db.ExecuteAsync("create table foo (value int, primary key (value))");
+            await db.ExecuteAsync("create table baz (value int, foovalue int, constraint FK_Foo foreign key (foovalue) references foo (value))");
 
             for (int i = 0; i < 100; i++)
             {
-                await _database.ExecuteAsync("INSERT INTO \"foo\" VALUES (@0)", i);
-                await _database.ExecuteAsync("INSERT INTO \"baz\" VALUES (@0, @0)", i);
+                await db.ExecuteAsync("INSERT INTO \"foo\" VALUES (@0)", i);
+                await db.ExecuteAsync("INSERT INTO \"baz\" VALUES (@0, @0)", i);
             }
 
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM foo").ShouldBe(100);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM baz").ShouldBe(100);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM foo").ShouldBe(100);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM baz").ShouldBe(100);
 
-            var checkpoint = await Respawner.CreateAsync(_connection, new RespawnerOptions
+            var checkpoint = await Respawner.CreateAsync(db.Connection, new RespawnerOptions
             {
                 SchemasToInclude = new [] { "public" }
             });
             try
             {
-                await checkpoint.ResetAsync(_connection);
+                await checkpoint.ResetAsync(db.Connection);
             }
             catch
             {
-                _output.WriteLine(checkpoint.DeleteSql ?? string.Empty);
+                output.WriteLine(checkpoint.DeleteSql ?? string.Empty);
                 throw;
             }
 
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM foo").ShouldBe(0);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM baz").ShouldBe(0);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM foo").ShouldBe(0);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM baz").ShouldBe(0);
         }
 
         [Fact]
         public async Task ShouldHandleCircularRelationships()
         {
-            await _database.ExecuteAsync("create table parent (id int primary key, childid int NULL)");
-            await _database.ExecuteAsync("create table child (id int primary key, parentid int NULL)");
-            await _database.ExecuteAsync("alter table parent add constraint FK_Child foreign key (ChildId) references Child (Id)");
-            await _database.ExecuteAsync("alter table child add constraint FK_Parent foreign key (ParentId) references Parent (Id)");
+            using var db = await fixture.CreateDatabaseAsync();
+
+            await db.ExecuteAsync("create table parent (id int primary key, childid int NULL)");
+            await db.ExecuteAsync("create table child (id int primary key, parentid int NULL)");
+            await db.ExecuteAsync("alter table parent add constraint FK_Child foreign key (ChildId) references Child (Id)");
+            await db.ExecuteAsync("alter table child add constraint FK_Parent foreign key (ParentId) references Parent (Id)");
 
             for (int i = 0; i < 100; i++)
             {
-                await _database.ExecuteAsync("INSERT INTO \"parent\" VALUES (@0, null)", i);
-                await _database.ExecuteAsync("INSERT INTO \"child\" VALUES (@0, null)", i);
+                await db.ExecuteAsync("INSERT INTO \"parent\" VALUES (@0, null)", i);
+                await db.ExecuteAsync("INSERT INTO \"child\" VALUES (@0, null)", i);
             }
 
-            await _database.ExecuteAsync("update parent set childid = 0");
-            await _database.ExecuteAsync("update child set parentid = 1");
+            await db.ExecuteAsync("update parent set childid = 0");
+            await db.ExecuteAsync("update child set parentid = 1");
 
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM parent").ShouldBe(100);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM child").ShouldBe(100);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM parent").ShouldBe(100);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM child").ShouldBe(100);
 
-            var checkpoint = await Respawner.CreateAsync(_connection);
+            var checkpoint = await Respawner.CreateAsync(db.Connection);
             try
             {
-                await checkpoint.ResetAsync(_connection);
+                await checkpoint.ResetAsync(db.Connection);
             }
             catch
             {
-                _output.WriteLine(checkpoint.DeleteSql ?? string.Empty);
+                output.WriteLine(checkpoint.DeleteSql ?? string.Empty);
                 throw;
             }
 
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM parent").ShouldBe(0);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM child").ShouldBe(0);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM parent").ShouldBe(0);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM child").ShouldBe(0);
         }
 
         [Fact]
         public async Task ShouldHandleSelfRelationships()
         {
-            await _database.ExecuteAsync("create table foo (id int primary key, parentid int NULL)");
-            await _database.ExecuteAsync("alter table foo add constraint FK_Parent foreign key (parentid) references foo (id)");
+            using var db = await fixture.CreateDatabaseAsync();
 
-            await _database.ExecuteAsync("INSERT INTO \"foo\" VALUES (@0)", 1);
+            await db.ExecuteAsync("create table foo (id int primary key, parentid int NULL)");
+            await db.ExecuteAsync("alter table foo add constraint FK_Parent foreign key (parentid) references foo (id)");
+
+            await db.ExecuteAsync("INSERT INTO \"foo\" VALUES (@0)", 1);
             for (int i = 1; i < 100; i++)
             {
-                await _database.ExecuteAsync("INSERT INTO \"foo\" VALUES (@0, @1)", i+1, i);
+                await db.ExecuteAsync("INSERT INTO \"foo\" VALUES (@0, @1)", i+1, i);
             }
 
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM foo").ShouldBe(100);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM foo").ShouldBe(100);
 
-            var checkpoint = await Respawner.CreateAsync(_connection);
+            var checkpoint = await Respawner.CreateAsync(db.Connection);
             try
             {
-                await checkpoint.ResetAsync(_connection);
+                await checkpoint.ResetAsync(db.Connection);
             }
             catch
             {
-                _output.WriteLine(checkpoint.DeleteSql ?? string.Empty);
+                output.WriteLine(checkpoint.DeleteSql ?? string.Empty);
                 throw;
             }
 
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM foo").ShouldBe(0);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM foo").ShouldBe(0);
         }
 
         [Fact]
         public async Task ShouldHandleComplexCycles()
         {
-            await _database.ExecuteAsync("create table a (id int primary key, b_id int NULL)");
-            await _database.ExecuteAsync("create table b (id int primary key, a_id int NULL, c_id int NULL, d_id int NULL)");
-            await _database.ExecuteAsync("create table c (id int primary key, d_id int NULL)");
-            await _database.ExecuteAsync("create table d (id int primary key)");
-            await _database.ExecuteAsync("create table e (id int primary key, a_id int NULL)");
-            await _database.ExecuteAsync("create table f (id int primary key, b_id int NULL)");
-            await _database.ExecuteAsync("alter table a add constraint FK_a_b foreign key (b_id) references b (id)");
-            await _database.ExecuteAsync("alter table b add constraint FK_b_a foreign key (a_id) references a (id)");
-            await _database.ExecuteAsync("alter table b add constraint FK_b_c foreign key (c_id) references c (id)");
-            await _database.ExecuteAsync("alter table b add constraint FK_b_d foreign key (d_id) references d (id)");
-            await _database.ExecuteAsync("alter table c add constraint FK_c_d foreign key (d_id) references d (id)");
-            await _database.ExecuteAsync("alter table e add constraint FK_e_a foreign key (a_id) references a (id)");
-            await _database.ExecuteAsync("alter table f add constraint FK_f_b foreign key (b_id) references b (id)");
+            using var db = await fixture.CreateDatabaseAsync();
+
+            await db.ExecuteAsync("create table a (id int primary key, b_id int NULL)");
+            await db.ExecuteAsync("create table b (id int primary key, a_id int NULL, c_id int NULL, d_id int NULL)");
+            await db.ExecuteAsync("create table c (id int primary key, d_id int NULL)");
+            await db.ExecuteAsync("create table d (id int primary key)");
+            await db.ExecuteAsync("create table e (id int primary key, a_id int NULL)");
+            await db.ExecuteAsync("create table f (id int primary key, b_id int NULL)");
+            await db.ExecuteAsync("alter table a add constraint FK_a_b foreign key (b_id) references b (id)");
+            await db.ExecuteAsync("alter table b add constraint FK_b_a foreign key (a_id) references a (id)");
+            await db.ExecuteAsync("alter table b add constraint FK_b_c foreign key (c_id) references c (id)");
+            await db.ExecuteAsync("alter table b add constraint FK_b_d foreign key (d_id) references d (id)");
+            await db.ExecuteAsync("alter table c add constraint FK_c_d foreign key (d_id) references d (id)");
+            await db.ExecuteAsync("alter table e add constraint FK_e_a foreign key (a_id) references a (id)");
+            await db.ExecuteAsync("alter table f add constraint FK_f_b foreign key (b_id) references b (id)");
 
 
-            await _database.ExecuteAsync("insert into d (id) values (1)");
-            await _database.ExecuteAsync("insert into c (id, d_id) values (1, 1)");
-            await _database.ExecuteAsync("insert into a (id) values (1)");
-            await _database.ExecuteAsync("insert into b (id, c_id, d_id) values (1, 1, 1)");
-            await _database.ExecuteAsync("insert into e (id, a_id) values (1, 1)");
-            await _database.ExecuteAsync("insert into f (id, b_id) values (1, 1)");
-            await _database.ExecuteAsync("update a set b_id = 1");
-            await _database.ExecuteAsync("update b set a_id = 1");
+            await db.ExecuteAsync("insert into d (id) values (1)");
+            await db.ExecuteAsync("insert into c (id, d_id) values (1, 1)");
+            await db.ExecuteAsync("insert into a (id) values (1)");
+            await db.ExecuteAsync("insert into b (id, c_id, d_id) values (1, 1, 1)");
+            await db.ExecuteAsync("insert into e (id, a_id) values (1, 1)");
+            await db.ExecuteAsync("insert into f (id, b_id) values (1, 1)");
+            await db.ExecuteAsync("update a set b_id = 1");
+            await db.ExecuteAsync("update b set a_id = 1");
 
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM a").ShouldBe(1);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM b").ShouldBe(1);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM c").ShouldBe(1);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM d").ShouldBe(1);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM e").ShouldBe(1);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM f").ShouldBe(1);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM a").ShouldBe(1);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM b").ShouldBe(1);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM c").ShouldBe(1);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM d").ShouldBe(1);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM e").ShouldBe(1);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM f").ShouldBe(1);
 
-            var checkpoint = await Respawner.CreateAsync(_connection);
+            var checkpoint = await Respawner.CreateAsync(db.Connection);
             try
             {
-                await checkpoint.ResetAsync(_connection);
+                await checkpoint.ResetAsync(db.Connection);
             }
             catch
             {
-                _output.WriteLine(checkpoint.DeleteSql ?? string.Empty);
+                output.WriteLine(checkpoint.DeleteSql ?? string.Empty);
                 throw;
             }
 
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM a").ShouldBe(0);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM b").ShouldBe(0);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM c").ShouldBe(0);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM d").ShouldBe(0);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM e").ShouldBe(0);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM f").ShouldBe(0);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM a").ShouldBe(0);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM b").ShouldBe(0);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM c").ShouldBe(0);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM d").ShouldBe(0);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM e").ShouldBe(0);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM f").ShouldBe(0);
         }
 
 
         [Fact]
         public async Task ShouldExcludeSchemas()
         {
-            await _database.ExecuteAsync("create schema a");
-            await _database.ExecuteAsync("create schema b");
-            await _database.ExecuteAsync("create table a.foo (value int)");
-            await _database.ExecuteAsync("create table b.bar (value int)");
+            using var db = await fixture.CreateDatabaseAsync();
+
+            await db.ExecuteAsync("create schema a");
+            await db.ExecuteAsync("create schema b");
+            await db.ExecuteAsync("create table a.foo (value int)");
+            await db.ExecuteAsync("create table b.bar (value int)");
 
             for (int i = 0; i < 100; i++)
             {
-                await _database.ExecuteAsync("INSERT INTO a.foo VALUES (" + i + ")");
-                await _database.ExecuteAsync("INSERT INTO b.bar VALUES (" + i + ")");
+                await db.ExecuteAsync("INSERT INTO a.foo VALUES (" + i + ")");
+                await db.ExecuteAsync("INSERT INTO b.bar VALUES (" + i + ")");
             }
 
-            var checkpoint = await Respawner.CreateAsync(_connection, new RespawnerOptions
+            var checkpoint = await Respawner.CreateAsync(db.Connection, new RespawnerOptions
             {
                 SchemasToExclude = new [] { "a" }
             });
-            await checkpoint.ResetAsync(_connection);
+            await checkpoint.ResetAsync(db.Connection);
 
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM a.foo").ShouldBe(100);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM b.bar").ShouldBe(0);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM a.foo").ShouldBe(100);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM b.bar").ShouldBe(0);
         }
 
         [Fact]
         public async Task ShouldIncludeSchemas()
         {
-            await _database.ExecuteAsync("create schema a");
-            await _database.ExecuteAsync("create schema b");
-            await _database.ExecuteAsync("create table a.foo (value int)");
-            await _database.ExecuteAsync("create table b.bar (value int)");
+            using var db = await fixture.CreateDatabaseAsync();
+
+            await db.ExecuteAsync("create schema a");
+            await db.ExecuteAsync("create schema b");
+            await db.ExecuteAsync("create table a.foo (value int)");
+            await db.ExecuteAsync("create table b.bar (value int)");
 
             for (int i = 0; i < 100; i++)
             {
-                await _database.ExecuteAsync("INSERT INTO a.foo VALUES (" + i + ")");
-                await _database.ExecuteAsync("INSERT INTO b.bar VALUES (" + i + ")");
+                await db.ExecuteAsync("INSERT INTO a.foo VALUES (" + i + ")");
+                await db.ExecuteAsync("INSERT INTO b.bar VALUES (" + i + ")");
             }
 
-            var checkpoint = await Respawner.CreateAsync(_connection, new RespawnerOptions
+            var checkpoint = await Respawner.CreateAsync(db.Connection, new RespawnerOptions
             {
                 SchemasToInclude = new [] { "b" }
             });
-            await checkpoint.ResetAsync(_connection);
+            await checkpoint.ResetAsync(db.Connection);
 
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM a.foo").ShouldBe(100);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM b.bar").ShouldBe(0);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM a.foo").ShouldBe(100);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM b.bar").ShouldBe(0);
         }
 
         [Fact]
         public async Task ShouldResetSequencesAndIdentities()
         {
-            await _database.ExecuteAsync("CREATE TABLE a (id INT GENERATED ALWAYS AS IDENTITY, value SERIAL)");
-            await _database.ExecuteAsync("INSERT INTO a DEFAULT VALUES");
-            await _database.ExecuteAsync("INSERT INTO a DEFAULT VALUES");
-            await _database.ExecuteAsync("INSERT INTO a DEFAULT VALUES");
+            using var db = await fixture.CreateDatabaseAsync();
 
-            var checkpoint = await Respawner.CreateAsync(_connection, new RespawnerOptions
+            await db.ExecuteAsync("CREATE TABLE a (id INT GENERATED ALWAYS AS IDENTITY, value SERIAL)");
+            await db.ExecuteAsync("INSERT INTO a DEFAULT VALUES");
+            await db.ExecuteAsync("INSERT INTO a DEFAULT VALUES");
+            await db.ExecuteAsync("INSERT INTO a DEFAULT VALUES");
+
+            var checkpoint = await Respawner.CreateAsync(db.Connection, new RespawnerOptions
             {
                 WithReseed = true
             });
 
-            await checkpoint.ResetAsync(_connection);
-            _database.ExecuteScalar<int>("SELECT nextval('a_id_seq')").ShouldBe(1);
-            _database.ExecuteScalar<int>("SELECT nextval('a_value_seq')").ShouldBe(1);
+            await checkpoint.ResetAsync(db.Connection);
+            db.ExecuteScalar<int>("SELECT nextval('a_id_seq')").ShouldBe(1);
+            db.ExecuteScalar<int>("SELECT nextval('a_value_seq')").ShouldBe(1);
         }
     }
 }

--- a/Respawn.DatabaseTests/Respawn.DatabaseTests.csproj
+++ b/Respawn.DatabaseTests/Respawn.DatabaseTests.csproj
@@ -12,11 +12,12 @@
     <PackageReference Include="Npgsql" Version="9.0.3" />
     <PackageReference Include="NPoco.SqlServer" Version="5.7.1" />
     <PackageReference Include="Shouldly" Version="4.0.3" />
-    <PackageReference Include="Testcontainers.Db2" Version="4.8.1" />
-    <PackageReference Include="Testcontainers.MsSql" Version="4.8.1" />
-    <PackageReference Include="Testcontainers.MySql" Version="4.8.1" />
-    <PackageReference Include="Testcontainers.Oracle" Version="4.8.1" />
-    <PackageReference Include="Testcontainers.PostgreSql" Version="4.8.1" />
+    <PackageReference Include="Testcontainers.Db2" Version="4.10.0" />
+    <PackageReference Include="Testcontainers.MsSql" Version="4.10.0" />
+    <PackageReference Include="Testcontainers.MySql" Version="4.10.0" />
+    <PackageReference Include="Testcontainers.Oracle" Version="4.10.0" />
+    <PackageReference Include="Testcontainers.PostgreSql" Version="4.10.0" />
+    <PackageReference Include="Testcontainers.Xunit" Version="4.10.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />

--- a/Respawn.DatabaseTests/SqlServerFixture.cs
+++ b/Respawn.DatabaseTests/SqlServerFixture.cs
@@ -1,0 +1,16 @@
+using System.Data.Common;
+using Microsoft.Data.SqlClient;
+using NPoco;
+using Testcontainers.MsSql;
+using Xunit.Abstractions;
+
+namespace Respawn.DatabaseTests;
+
+public class SqlServerFixture(IMessageSink messageSink) : DbFixture<MsSqlBuilder, MsSqlContainer>(messageSink)
+{
+    public override DbProviderFactory DbProviderFactory => SqlClientFactory.Instance;
+
+    protected override DatabaseType DbType => DatabaseType.SqlServer2012;
+
+    protected override MsSqlBuilder CreateBuilder() => new("mcr.microsoft.com/mssql/server:2022-CU23-ubuntu-22.04");
+}

--- a/Respawn.DatabaseTests/SqlServerTests.cs
+++ b/Respawn.DatabaseTests/SqlServerTests.cs
@@ -1,24 +1,16 @@
 ﻿using System.Threading.Tasks;
-using Microsoft.Data.SqlClient;
 using Respawn.Graph;
-using Testcontainers.MsSql;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace Respawn.DatabaseTests
 {
-    using System;
     using System.Linq;
     using NPoco;
     using Shouldly;
 
-    public class SqlServerTests : IAsyncLifetime
+    public class SqlServerTests(ITestOutputHelper output, SqlServerFixture fixture) : IClassFixture<SqlServerFixture>
     {
-        private readonly ITestOutputHelper _output;
-        private SqlConnection _connection;
-        private Database _database;
-        private MsSqlContainer _sqlContainer;
-
         public class Foo
         {
             public int Value { get; set; }
@@ -47,84 +39,46 @@ namespace Respawn.DatabaseTests
             public int? ParentId { get; set; }
         }
 
-        public SqlServerTests(ITestOutputHelper output) => _output = output;
-
-        public async Task InitializeAsync()
-        {
-            _sqlContainer = new MsSqlBuilder()
-                .WithImage("mcr.microsoft.com/mssql/server:2022-CU10-ubuntu-22.04")
-                .Build();
-            await _sqlContainer.StartAsync();
-            
-            var connString = _sqlContainer.GetConnectionString();
-
-            await using (var connection = new SqlConnection(connString))
-            {
-                await connection.OpenAsync();
-                using (var database = new Database(connection))
-                {
-                    await database.ExecuteAsync(@"IF EXISTS (SELECT name FROM master.dbo.sysdatabases WHERE name = N'SqlServerTests') alter database SqlServerTests set single_user with rollback immediate");
-                    await database.ExecuteAsync(@"DROP DATABASE IF EXISTS SqlServerTests");
-                    await database.ExecuteAsync("create database [SqlServerTests]");
-                }
-            }
-            
-            var newConnString = new SqlConnectionStringBuilder(connString)
-            {
-                InitialCatalog = "SqlServerTests"
-            }.ConnectionString;
-
-            _connection = new SqlConnection(newConnString);
-            _connection.Open();
-
-            _database = new Database(_connection);
-        }
-
-        public async Task DisposeAsync()
-        {
-            _connection?.Close();
-            _connection?.Dispose();
-            _connection = null;
-            await _sqlContainer.StopAsync();
-            await _sqlContainer.DisposeAsync();
-        }
-
         [Fact]
         public async Task ShouldDeleteData()
         {
-            await _database.ExecuteAsync("create table Foo (Value [int])");
+            using var db = await fixture.CreateDatabaseAsync();
 
-            await _database.InsertBulkAsync(Enumerable.Range(0, 100).Select(i => new Foo { Value = i }));
+            await db.ExecuteAsync("create table Foo (Value [int])");
 
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM Foo").ShouldBe(100);
+            await db.InsertBulkAsync(Enumerable.Range(0, 100).Select(i => new Foo { Value = i }));
 
-            var checkpoint = await Respawner.CreateAsync(_connection);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM Foo").ShouldBe(100);
+
+            var checkpoint = await Respawner.CreateAsync(db.Connection);
             try
             {
-                await checkpoint.ResetAsync(_connection);
+                await checkpoint.ResetAsync(db.Connection);
             }
             catch
             {
-                _output.WriteLine(checkpoint.DeleteSql);
+                output.WriteLine(checkpoint.DeleteSql);
                 throw;
             }
 
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM Foo").ShouldBe(0);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM Foo").ShouldBe(0);
         }
 
         [Fact]
         public async Task ShouldDeleteDataUsingCustomDeleteStatements()
         {
-            await _database.ExecuteAsync("create table Foo (Value [int])");
-            await _database.ExecuteAsync("create table Bar (Value [int])");
+            using var db = await fixture.CreateDatabaseAsync();
 
-            await _database.InsertBulkAsync(Enumerable.Range(0, 100).Select(i => new Foo { Value = i }));
-            await _database.InsertBulkAsync(Enumerable.Range(0, 100).Select(i => new Bar { Value = i }));
+            await db.ExecuteAsync("create table Foo (Value [int])");
+            await db.ExecuteAsync("create table Bar (Value [int])");
 
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM Foo").ShouldBe(100);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM Bar").ShouldBe(100);
+            await db.InsertBulkAsync(Enumerable.Range(0, 100).Select(i => new Foo { Value = i }));
+            await db.InsertBulkAsync(Enumerable.Range(0, 100).Select(i => new Bar { Value = i }));
 
-            var checkpoint = await Respawner.CreateAsync(_connection, new RespawnerOptions()
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM Foo").ShouldBe(100);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM Bar").ShouldBe(100);
+
+            var checkpoint = await Respawner.CreateAsync(db.Connection, new RespawnerOptions()
             {
                 FormatDeleteStatement = table =>
                 {
@@ -141,207 +95,219 @@ namespace Respawn.DatabaseTests
 
             try
             {
-                await checkpoint.ResetAsync(_connection);
+                await checkpoint.ResetAsync(db.Connection);
             }
             catch
             {
-                _output.WriteLine(checkpoint.DeleteSql);
+                output.WriteLine(checkpoint.DeleteSql);
                 throw;
             }
 
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM Foo").ShouldBe(21);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM Bar").ShouldBe(31);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM Foo").ShouldBe(21);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM Bar").ShouldBe(31);
         }
 
         [Fact]
         public async Task ShouldHandleRelationships()
         {
-            await _database.ExecuteAsync("create table Foo (Value [int], constraint PK_Foo primary key nonclustered (value))");
-            await _database.ExecuteAsync("create table Baz (Value [int], FooValue [int], constraint FK_Foo foreign key (FooValue) references Foo (Value))");
+            using var db = await fixture.CreateDatabaseAsync();
 
-            await _database.InsertBulkAsync(Enumerable.Range(0, 100).Select(i => new Foo { Value = i }));
-            await _database.InsertBulkAsync(Enumerable.Range(0, 100).Select(i => new Baz { Value = i, FooValue = i }));
+            await db.ExecuteAsync("create table Foo (Value [int], constraint PK_Foo primary key nonclustered (value))");
+            await db.ExecuteAsync("create table Baz (Value [int], FooValue [int], constraint FK_Foo foreign key (FooValue) references Foo (Value))");
 
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM Foo").ShouldBe(100);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM Baz").ShouldBe(100);
+            await db.InsertBulkAsync(Enumerable.Range(0, 100).Select(i => new Foo { Value = i }));
+            await db.InsertBulkAsync(Enumerable.Range(0, 100).Select(i => new Baz { Value = i, FooValue = i }));
 
-            var checkpoint = await Respawner.CreateAsync(_connection);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM Foo").ShouldBe(100);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM Baz").ShouldBe(100);
+
+            var checkpoint = await Respawner.CreateAsync(db.Connection);
             try
             {
-                await checkpoint.ResetAsync(_connection);
+                await checkpoint.ResetAsync(db.Connection);
             }
             catch
             {
-                _output.WriteLine(checkpoint.DeleteSql);
+                output.WriteLine(checkpoint.DeleteSql);
                 throw;
             }
 
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM Foo").ShouldBe(0);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM Baz").ShouldBe(0);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM Foo").ShouldBe(0);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM Baz").ShouldBe(0);
         }
 
         [Fact]
         public async Task ShouldHandleSelfRelationships()
         {
-            await _database.ExecuteAsync("create table circle (id int primary key, parentid int NULL)");
-            await _database.ExecuteAsync("alter table circle add constraint FK_Parent foreign key (parentid) references circle (id)");
+            using var db = await fixture.CreateDatabaseAsync();
 
-            await _database.ExecuteAsync("INSERT INTO \"circle\" (id) VALUES (@0)", 1);
+            await db.ExecuteAsync("create table circle (id int primary key, parentid int NULL)");
+            await db.ExecuteAsync("alter table circle add constraint FK_Parent foreign key (parentid) references circle (id)");
+
+            await db.ExecuteAsync("INSERT INTO \"circle\" (id) VALUES (@0)", 1);
             for (int i = 1; i < 100; i++)
             {
-                await _database.ExecuteAsync("INSERT INTO \"circle\" (id, parentid) VALUES (@0, @1)", i + 1, i);
+                await db.ExecuteAsync("INSERT INTO \"circle\" (id, parentid) VALUES (@0, @1)", i + 1, i);
             }
 
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM circle").ShouldBe(100);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM circle").ShouldBe(100);
 
-            var checkpoint = await Respawner.CreateAsync(_connection);
+            var checkpoint = await Respawner.CreateAsync(db.Connection);
             try
             {
-                await checkpoint.ResetAsync(_connection);
+                await checkpoint.ResetAsync(db.Connection);
             }
             catch
             {
-                _output.WriteLine(checkpoint.DeleteSql ?? string.Empty);
+                output.WriteLine(checkpoint.DeleteSql ?? string.Empty);
                 throw;
             }
 
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM circle").ShouldBe(0);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM circle").ShouldBe(0);
         }
 
         [Fact]
         public async Task ShouldHandleComplexCycles()
         {
-            await _database.ExecuteAsync("create table a (id int primary key, b_id int NULL)");
-            await _database.ExecuteAsync("create table b (id int primary key, a_id int NULL, c_id int NULL, d_id int NULL)");
-            await _database.ExecuteAsync("create table c (id int primary key, d_id int NULL)");
-            await _database.ExecuteAsync("create table d (id int primary key)");
-            await _database.ExecuteAsync("create table e (id int primary key, a_id int NULL)");
-            await _database.ExecuteAsync("create table f (id int primary key, b_id int NULL)");
-            await _database.ExecuteAsync("alter table a add constraint FK_a_b foreign key (b_id) references b (id)");
-            await _database.ExecuteAsync("alter table b add constraint FK_b_a foreign key (a_id) references a (id)");
-            await _database.ExecuteAsync("alter table b add constraint FK_b_c foreign key (c_id) references c (id)");
-            await _database.ExecuteAsync("alter table b add constraint FK_b_d foreign key (d_id) references d (id)");
-            await _database.ExecuteAsync("alter table c add constraint FK_c_d foreign key (d_id) references d (id)");
-            await _database.ExecuteAsync("alter table e add constraint FK_e_a foreign key (a_id) references a (id)");
-            await _database.ExecuteAsync("alter table f add constraint FK_f_b foreign key (b_id) references b (id)");
+            using var db = await fixture.CreateDatabaseAsync();
+
+            await db.ExecuteAsync("create table a (id int primary key, b_id int NULL)");
+            await db.ExecuteAsync("create table b (id int primary key, a_id int NULL, c_id int NULL, d_id int NULL)");
+            await db.ExecuteAsync("create table c (id int primary key, d_id int NULL)");
+            await db.ExecuteAsync("create table d (id int primary key)");
+            await db.ExecuteAsync("create table e (id int primary key, a_id int NULL)");
+            await db.ExecuteAsync("create table f (id int primary key, b_id int NULL)");
+            await db.ExecuteAsync("alter table a add constraint FK_a_b foreign key (b_id) references b (id)");
+            await db.ExecuteAsync("alter table b add constraint FK_b_a foreign key (a_id) references a (id)");
+            await db.ExecuteAsync("alter table b add constraint FK_b_c foreign key (c_id) references c (id)");
+            await db.ExecuteAsync("alter table b add constraint FK_b_d foreign key (d_id) references d (id)");
+            await db.ExecuteAsync("alter table c add constraint FK_c_d foreign key (d_id) references d (id)");
+            await db.ExecuteAsync("alter table e add constraint FK_e_a foreign key (a_id) references a (id)");
+            await db.ExecuteAsync("alter table f add constraint FK_f_b foreign key (b_id) references b (id)");
 
 
-            await _database.ExecuteAsync("insert into d (id) values (1)");
-            await _database.ExecuteAsync("insert into c (id, d_id) values (1, 1)");
-            await _database.ExecuteAsync("insert into a (id) values (1)");
-            await _database.ExecuteAsync("insert into b (id, c_id, d_id) values (1, 1, 1)");
-            await _database.ExecuteAsync("insert into e (id, a_id) values (1, 1)");
-            await _database.ExecuteAsync("insert into f (id, b_id) values (1, 1)");
-            await _database.ExecuteAsync("update a set b_id = 1");
-            await _database.ExecuteAsync("update b set a_id = 1");
+            await db.ExecuteAsync("insert into d (id) values (1)");
+            await db.ExecuteAsync("insert into c (id, d_id) values (1, 1)");
+            await db.ExecuteAsync("insert into a (id) values (1)");
+            await db.ExecuteAsync("insert into b (id, c_id, d_id) values (1, 1, 1)");
+            await db.ExecuteAsync("insert into e (id, a_id) values (1, 1)");
+            await db.ExecuteAsync("insert into f (id, b_id) values (1, 1)");
+            await db.ExecuteAsync("update a set b_id = 1");
+            await db.ExecuteAsync("update b set a_id = 1");
 
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM a").ShouldBe(1);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM b").ShouldBe(1);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM c").ShouldBe(1);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM d").ShouldBe(1);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM e").ShouldBe(1);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM f").ShouldBe(1);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM a").ShouldBe(1);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM b").ShouldBe(1);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM c").ShouldBe(1);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM d").ShouldBe(1);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM e").ShouldBe(1);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM f").ShouldBe(1);
 
-            var checkpoint = await Respawner.CreateAsync(_connection);
+            var checkpoint = await Respawner.CreateAsync(db.Connection);
             try
             {
-                await checkpoint.ResetAsync(_connection);
+                await checkpoint.ResetAsync(db.Connection);
             }
             catch
             {
-                _output.WriteLine(checkpoint.DeleteSql ?? string.Empty);
+                output.WriteLine(checkpoint.DeleteSql ?? string.Empty);
                 throw;
             }
 
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM a").ShouldBe(0);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM b").ShouldBe(0);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM c").ShouldBe(0);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM d").ShouldBe(0);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM e").ShouldBe(0);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM f").ShouldBe(0);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM a").ShouldBe(0);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM b").ShouldBe(0);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM c").ShouldBe(0);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM d").ShouldBe(0);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM e").ShouldBe(0);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM f").ShouldBe(0);
         }
 
         [Fact]
         public async Task ShouldHandleCircularRelationships()
         {
-            await _database.ExecuteAsync("create table Parent (Id [int] NOT NULL, ChildId [int] NULL, constraint PK_Parent primary key clustered (Id))");
-            await _database.ExecuteAsync("create table Child (Id [int] NOT NULL, ParentId [int] NULL, constraint PK_Child primary key clustered (Id))");
-            await _database.ExecuteAsync("alter table Parent add constraint FK_Child foreign key (ChildId) references Child (Id)");
-            await _database.ExecuteAsync("alter table Child add constraint FK_Parent foreign key (ParentId) references Parent (Id)");
+            using var db = await fixture.CreateDatabaseAsync();
 
-            await _database.InsertBulkAsync(Enumerable.Range(0, 100).Select(i => new Parent { Id = i, ChildId = null }));
-            await _database.InsertBulkAsync(Enumerable.Range(0, 100).Select(i => new Child { Id = i, ParentId = null }));
+            await db.ExecuteAsync("create table Parent (Id [int] NOT NULL, ChildId [int] NULL, constraint PK_Parent primary key clustered (Id))");
+            await db.ExecuteAsync("create table Child (Id [int] NOT NULL, ParentId [int] NULL, constraint PK_Child primary key clustered (Id))");
+            await db.ExecuteAsync("alter table Parent add constraint FK_Child foreign key (ChildId) references Child (Id)");
+            await db.ExecuteAsync("alter table Child add constraint FK_Parent foreign key (ParentId) references Parent (Id)");
 
-            await _database.ExecuteAsync("update Parent set ChildId = 0");
-            await _database.ExecuteAsync("update Child set ParentId = 1");
+            await db.InsertBulkAsync(Enumerable.Range(0, 100).Select(i => new Parent { Id = i, ChildId = null }));
+            await db.InsertBulkAsync(Enumerable.Range(0, 100).Select(i => new Child { Id = i, ParentId = null }));
 
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM Parent").ShouldBe(100);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM Child").ShouldBe(100);
+            await db.ExecuteAsync("update Parent set ChildId = 0");
+            await db.ExecuteAsync("update Child set ParentId = 1");
 
-            var checkpoint = await Respawner.CreateAsync(_connection);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM Parent").ShouldBe(100);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM Child").ShouldBe(100);
+
+            var checkpoint = await Respawner.CreateAsync(db.Connection);
             try
             {
-                await checkpoint.ResetAsync(_connection);
+                await checkpoint.ResetAsync(db.Connection);
             }
             catch
             {
-                _output.WriteLine(checkpoint.DeleteSql);
+                output.WriteLine(checkpoint.DeleteSql);
                 throw;
             }
 
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM Parent").ShouldBe(0);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM Child").ShouldBe(0);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM Parent").ShouldBe(0);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM Child").ShouldBe(0);
         }
 
         [Fact]
         public async Task ShouldIgnoreTables()
         {
-            await _database.ExecuteAsync("create table Foo (Value [int])");
-            await _database.ExecuteAsync("create table Bar (Value [int])");
+            using var db = await fixture.CreateDatabaseAsync();
 
-            await _database.InsertBulkAsync(Enumerable.Range(0, 100).Select(i => new Foo { Value = i }));
-            await _database.InsertBulkAsync(Enumerable.Range(0, 100).Select(i => new Bar { Value = i }));
+            await db.ExecuteAsync("create table Foo (Value [int])");
+            await db.ExecuteAsync("create table Bar (Value [int])");
 
-            var checkpoint = await Respawner.CreateAsync(_connection, new RespawnerOptions
+            await db.InsertBulkAsync(Enumerable.Range(0, 100).Select(i => new Foo { Value = i }));
+            await db.InsertBulkAsync(Enumerable.Range(0, 100).Select(i => new Bar { Value = i }));
+
+            var checkpoint = await Respawner.CreateAsync(db.Connection, new RespawnerOptions
             {
                 TablesToIgnore = new Table[] { "Foo" }
             });
             try
             {
-                await checkpoint.ResetAsync(_connection);
+                await checkpoint.ResetAsync(db.Connection);
             }
             catch
             {
-                _output.WriteLine(checkpoint.DeleteSql);
+                output.WriteLine(checkpoint.DeleteSql);
                 throw;
             }
 
-            _output.WriteLine(checkpoint.DeleteSql);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM Foo").ShouldBe(100);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM Bar").ShouldBe(0);
+            output.WriteLine(checkpoint.DeleteSql);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM Foo").ShouldBe(100);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM Bar").ShouldBe(0);
         }
 
         [Fact]
         public async Task ShouldIgnoreTablesWithSchema()
         {
-            await _database.ExecuteAsync("drop schema if exists A");
-            await _database.ExecuteAsync("drop schema if exists B");
-            await _database.ExecuteAsync("create schema A");
-            await _database.ExecuteAsync("create schema B");
-            await _database.ExecuteAsync("create table A.Foo (Value [int])");
-            await _database.ExecuteAsync("create table A.FooWithBrackets (Value [int])");
-            await _database.ExecuteAsync("create table B.Bar (Value [int])");
-            await _database.ExecuteAsync("create table B.Foo (Value [int])");
+            using var db = await fixture.CreateDatabaseAsync();
+
+            await db.ExecuteAsync("drop schema if exists A");
+            await db.ExecuteAsync("drop schema if exists B");
+            await db.ExecuteAsync("create schema A");
+            await db.ExecuteAsync("create schema B");
+            await db.ExecuteAsync("create table A.Foo (Value [int])");
+            await db.ExecuteAsync("create table A.FooWithBrackets (Value [int])");
+            await db.ExecuteAsync("create table B.Bar (Value [int])");
+            await db.ExecuteAsync("create table B.Foo (Value [int])");
 
             for (var i = 0; i < 100; i++)
             {
-                await _database.ExecuteAsync("INSERT A.Foo VALUES (" + i + ")");
-                await _database.ExecuteAsync("INSERT A.FooWithBrackets VALUES (" + i + ")");
-                await _database.ExecuteAsync("INSERT B.Bar VALUES (" + i + ")");
-                await _database.ExecuteAsync("INSERT B.Foo VALUES (" + i + ")");
+                await db.ExecuteAsync("INSERT A.Foo VALUES (" + i + ")");
+                await db.ExecuteAsync("INSERT A.FooWithBrackets VALUES (" + i + ")");
+                await db.ExecuteAsync("INSERT B.Bar VALUES (" + i + ")");
+                await db.ExecuteAsync("INSERT B.Foo VALUES (" + i + ")");
             }
 
-            var checkpoint = await Respawner.CreateAsync(_connection, new RespawnerOptions
+            var checkpoint = await Respawner.CreateAsync(db.Connection, new RespawnerOptions
             {
                 TablesToIgnore = new[]
                 {
@@ -351,498 +317,532 @@ namespace Respawn.DatabaseTests
             });
             try
             {
-                await checkpoint.ResetAsync(_connection);
+                await checkpoint.ResetAsync(db.Connection);
             }
             catch
             {
-                _output.WriteLine(checkpoint.DeleteSql);
+                output.WriteLine(checkpoint.DeleteSql);
                 throw;
             }
 
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM A.Foo").ShouldBe(100);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM A.FooWithBrackets").ShouldBe(100);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM B.Bar").ShouldBe(0);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM B.Foo").ShouldBe(0);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM A.Foo").ShouldBe(100);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM A.FooWithBrackets").ShouldBe(100);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM B.Bar").ShouldBe(0);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM B.Foo").ShouldBe(0);
         }
 
         [Fact]
         public async Task ShouldIncludeTables()
         {
-            await _database.ExecuteAsync("create table Foo (Value [int])");
-            await _database.ExecuteAsync("create table Bar (Value [int])");
+            using var db = await fixture.CreateDatabaseAsync();
 
-            await _database.InsertBulkAsync(Enumerable.Range(0, 100).Select(i => new Foo { Value = i }));
-            await _database.InsertBulkAsync(Enumerable.Range(0, 100).Select(i => new Bar { Value = i }));
+            await db.ExecuteAsync("create table Foo (Value [int])");
+            await db.ExecuteAsync("create table Bar (Value [int])");
 
-            var checkpoint = await Respawner.CreateAsync(_connection, new RespawnerOptions
+            await db.InsertBulkAsync(Enumerable.Range(0, 100).Select(i => new Foo { Value = i }));
+            await db.InsertBulkAsync(Enumerable.Range(0, 100).Select(i => new Bar { Value = i }));
+
+            var checkpoint = await Respawner.CreateAsync(db.Connection, new RespawnerOptions
             {
                 TablesToInclude = new Table[] { "Foo" }
             });
             try
             {
-                await checkpoint.ResetAsync(_connection);
+                await checkpoint.ResetAsync(db.Connection);
             }
             catch
             {
-                _output.WriteLine(checkpoint.DeleteSql);
+                output.WriteLine(checkpoint.DeleteSql);
                 throw;
             }
 
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM Foo").ShouldBe(0);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM Bar").ShouldBe(100);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM Foo").ShouldBe(0);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM Bar").ShouldBe(100);
         }
 
         [Fact]
         public async Task ShouldExcludeSchemas()
         {
-            await _database.ExecuteAsync("drop schema if exists A");
-            await _database.ExecuteAsync("drop schema if exists B");
-            await _database.ExecuteAsync("create schema A");
-            await _database.ExecuteAsync("create schema B");
-            await _database.ExecuteAsync("create table A.Foo (Value [int])");
-            await _database.ExecuteAsync("create table B.Bar (Value [int])");
+            using var db = await fixture.CreateDatabaseAsync();
+
+            await db.ExecuteAsync("drop schema if exists A");
+            await db.ExecuteAsync("drop schema if exists B");
+            await db.ExecuteAsync("create schema A");
+            await db.ExecuteAsync("create schema B");
+            await db.ExecuteAsync("create table A.Foo (Value [int])");
+            await db.ExecuteAsync("create table B.Bar (Value [int])");
 
             for (int i = 0; i < 100; i++)
             {
-                await _database.ExecuteAsync("INSERT A.Foo VALUES (" + i + ")");
-                await _database.ExecuteAsync("INSERT B.Bar VALUES (" + i + ")");
+                await db.ExecuteAsync("INSERT A.Foo VALUES (" + i + ")");
+                await db.ExecuteAsync("INSERT B.Bar VALUES (" + i + ")");
             }
 
-            var checkpoint = await Respawner.CreateAsync(_connection, new RespawnerOptions
+            var checkpoint = await Respawner.CreateAsync(db.Connection, new RespawnerOptions
             {
                 SchemasToExclude = new[] { "A" }
             });
             try
             {
-                await checkpoint.ResetAsync(_connection);
+                await checkpoint.ResetAsync(db.Connection);
             }
             catch
             {
-                _output.WriteLine(checkpoint.DeleteSql);
+                output.WriteLine(checkpoint.DeleteSql);
                 throw;
             }
 
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM A.Foo").ShouldBe(100);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM B.Bar").ShouldBe(0);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM A.Foo").ShouldBe(100);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM B.Bar").ShouldBe(0);
         }
 
         [Fact]
         public async Task ShouldIncludeSchemas()
         {
-            await _database.ExecuteAsync("drop schema if exists A");
-            await _database.ExecuteAsync("drop schema if exists B");
-            await _database.ExecuteAsync("create schema A");
-            await _database.ExecuteAsync("create schema B");
-            await _database.ExecuteAsync("create table A.Foo (Value [int])");
-            await _database.ExecuteAsync("create table B.Bar (Value [int])");
+            using var db = await fixture.CreateDatabaseAsync();
+
+            await db.ExecuteAsync("drop schema if exists A");
+            await db.ExecuteAsync("drop schema if exists B");
+            await db.ExecuteAsync("create schema A");
+            await db.ExecuteAsync("create schema B");
+            await db.ExecuteAsync("create table A.Foo (Value [int])");
+            await db.ExecuteAsync("create table B.Bar (Value [int])");
 
             for (int i = 0; i < 100; i++)
             {
-                await _database.ExecuteAsync("INSERT A.Foo VALUES (" + i + ")");
-                await _database.ExecuteAsync("INSERT B.Bar VALUES (" + i + ")");
+                await db.ExecuteAsync("INSERT A.Foo VALUES (" + i + ")");
+                await db.ExecuteAsync("INSERT B.Bar VALUES (" + i + ")");
             }
 
-            var checkpoint = await Respawner.CreateAsync(_connection, new RespawnerOptions
+            var checkpoint = await Respawner.CreateAsync(db.Connection, new RespawnerOptions
             {
                 SchemasToInclude = new[] { "B" }
             });
             try
             {
-                await checkpoint.ResetAsync(_connection);
+                await checkpoint.ResetAsync(db.Connection);
             }
             catch
             {
-                _output.WriteLine(checkpoint.DeleteSql);
+                output.WriteLine(checkpoint.DeleteSql);
                 throw;
             }
 
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM A.Foo").ShouldBe(100);
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM B.Bar").ShouldBe(0);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM A.Foo").ShouldBe(100);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM B.Bar").ShouldBe(0);
         }
 
         [Fact]
         public async Task ShouldReseedId()
         {
-            await _database.ExecuteAsync("create table Foo ([id] [int] IDENTITY(1,1), Value int)");
+            using var db = await fixture.CreateDatabaseAsync();
 
-            await _database.InsertBulkAsync(Enumerable.Range(0, 100).Select(i => new Foo { Value = i }));
+            await db.ExecuteAsync("create table Foo ([id] [int] IDENTITY(1,1), Value int)");
 
-            _database.ExecuteScalar<int>("SELECT MAX(id) FROM Foo").ShouldBe(100);
+            await db.InsertBulkAsync(Enumerable.Range(0, 100).Select(i => new Foo { Value = i }));
 
-            var checkpoint = await Respawner.CreateAsync(_connection, new RespawnerOptions
+            db.ExecuteScalar<int>("SELECT MAX(id) FROM Foo").ShouldBe(100);
+
+            var checkpoint = await Respawner.CreateAsync(db.Connection, new RespawnerOptions
             {
                 WithReseed = true
             });
             try
             {
-                await checkpoint.ResetAsync(_connection);
+                await checkpoint.ResetAsync(db.Connection);
             }
             catch
             {
-                _output.WriteLine(checkpoint.ReseedSql);
+                output.WriteLine(checkpoint.ReseedSql);
                 throw;
             }
 
-            await _database.InsertAsync(new Foo {Value = 0});
-            _database.ExecuteScalar<int>("SELECT MAX(id) FROM Foo").ShouldBe(1);
+            await db.InsertAsync(new Foo {Value = 0});
+            db.ExecuteScalar<int>("SELECT MAX(id) FROM Foo").ShouldBe(1);
         }
 
         [Fact]
         public async Task ShouldReseedId_TableWithSchema()
         {
-            await _database.ExecuteAsync("IF EXISTS (SELECT * FROM sys.schemas WHERE name = 'A') DROP SCHEMA A");
-            await _database.ExecuteAsync("create schema A");
-            await _database.ExecuteAsync("create table A.Foo ([id] [int] IDENTITY(1,1), Value int)");
+            using var db = await fixture.CreateDatabaseAsync();
+
+            await db.ExecuteAsync("IF EXISTS (SELECT * FROM sys.schemas WHERE name = 'A') DROP SCHEMA A");
+            await db.ExecuteAsync("create schema A");
+            await db.ExecuteAsync("create table A.Foo ([id] [int] IDENTITY(1,1), Value int)");
 
             for (int i = 0; i < 100; i++)
             {
-                await _database.ExecuteAsync("INSERT A.Foo VALUES (" + i + ")");
+                await db.ExecuteAsync("INSERT A.Foo VALUES (" + i + ")");
             }
 
-            _database.ExecuteScalar<int>("SELECT MAX(id) FROM A.Foo").ShouldBe(100);
+            db.ExecuteScalar<int>("SELECT MAX(id) FROM A.Foo").ShouldBe(100);
 
-            var checkpoint = await Respawner.CreateAsync(_connection, new RespawnerOptions
+            var checkpoint = await Respawner.CreateAsync(db.Connection, new RespawnerOptions
             {
                 WithReseed = true
             });
             try
             {
-                await checkpoint.ResetAsync(_connection);
+                await checkpoint.ResetAsync(db.Connection);
             }
             catch
             {
-                _output.WriteLine(checkpoint.ReseedSql);
+                output.WriteLine(checkpoint.ReseedSql);
                 throw;
             }
 
-            await _database.ExecuteAsync("INSERT A.Foo VALUES (0)");
+            await db.ExecuteAsync("INSERT A.Foo VALUES (0)");
 
-            _database.ExecuteScalar<int>("SELECT MAX(id) FROM A.Foo").ShouldBe(1);
+            db.ExecuteScalar<int>("SELECT MAX(id) FROM A.Foo").ShouldBe(1);
         }
 
         [Fact]
         public async Task ShouldReseedId_TableHasNeverHadAnyData()
         {
-            await _database.ExecuteAsync("drop schema if exists A");
-            await _database.ExecuteAsync("create schema A");
-            await _database.ExecuteAsync("create table A.Foo ([id] [int] IDENTITY(1,1), Value int)");
-            var checkpoint = await Respawner.CreateAsync(_connection, new RespawnerOptions
+            using var db = await fixture.CreateDatabaseAsync();
+
+            await db.ExecuteAsync("drop schema if exists A");
+            await db.ExecuteAsync("create schema A");
+            await db.ExecuteAsync("create table A.Foo ([id] [int] IDENTITY(1,1), Value int)");
+            var checkpoint = await Respawner.CreateAsync(db.Connection, new RespawnerOptions
             {
                 WithReseed = true
             });
             try
             {
-                await checkpoint.ResetAsync(_connection);
+                await checkpoint.ResetAsync(db.Connection);
             }
             catch
             {
-                _output.WriteLine(checkpoint.ReseedSql);
+                output.WriteLine(checkpoint.ReseedSql);
                 throw;
             }
 
-            await _database.ExecuteAsync("INSERT A.Foo VALUES (0)");
-            _database.ExecuteScalar<int>("SELECT MAX(id) FROM A.Foo").ShouldBe(1);
+            await db.ExecuteAsync("INSERT A.Foo VALUES (0)");
+            db.ExecuteScalar<int>("SELECT MAX(id) FROM A.Foo").ShouldBe(1);
         }
 
         [Fact]
         public async Task ShouldReseedId_TableWithSchemaHasNeverHadAnyData()
         {
-            await _database.ExecuteAsync("create table Foo ([id] [int] IDENTITY(1,1), Value int)");
-            var checkpoint = await Respawner.CreateAsync(_connection, new RespawnerOptions
+            using var db = await fixture.CreateDatabaseAsync();
+
+            await db.ExecuteAsync("create table Foo ([id] [int] IDENTITY(1,1), Value int)");
+            var checkpoint = await Respawner.CreateAsync(db.Connection, new RespawnerOptions
             {
                 WithReseed = true
             });
             try
             {
-                await checkpoint.ResetAsync(_connection);
+                await checkpoint.ResetAsync(db.Connection);
             }
             catch
             {
-                _output.WriteLine(checkpoint.ReseedSql);
+                output.WriteLine(checkpoint.ReseedSql);
                 throw;
             }
 
-            await _database.InsertAsync(new Foo { Value = 0 });
-            _database.ExecuteScalar<int>("SELECT MAX(id) FROM Foo").ShouldBe(1);
+            await db.InsertAsync(new Foo { Value = 0 });
+            db.ExecuteScalar<int>("SELECT MAX(id) FROM Foo").ShouldBe(1);
         }
 
         [Fact]
         public async Task ShouldNotReseedId()
         {
-            await _database.ExecuteAsync("create table Foo ([id] [int] IDENTITY(1,1), Value int)");
+            using var db = await fixture.CreateDatabaseAsync();
 
-            await _database.InsertBulkAsync(Enumerable.Range(0, 100).Select(i => new Foo { Value = i }));
+            await db.ExecuteAsync("create table Foo ([id] [int] IDENTITY(1,1), Value int)");
 
-            _database.ExecuteScalar<int>("SELECT MAX(id) FROM Foo").ShouldBe(100);
+            await db.InsertBulkAsync(Enumerable.Range(0, 100).Select(i => new Foo { Value = i }));
 
-            var checkpoint = await Respawner.CreateAsync(_connection, new RespawnerOptions
+            db.ExecuteScalar<int>("SELECT MAX(id) FROM Foo").ShouldBe(100);
+
+            var checkpoint = await Respawner.CreateAsync(db.Connection, new RespawnerOptions
             {
                 WithReseed = false
             });
             try
             {
-                await checkpoint.ResetAsync(_connection);
+                await checkpoint.ResetAsync(db.Connection);
             }
             catch
             {
-                _output.WriteLine(checkpoint.ReseedSql);
+                output.WriteLine(checkpoint.ReseedSql);
                 throw;
             }
 
-            await _database.InsertAsync(new Foo { Value = 0 });
-            _database.ExecuteScalar<int>("SELECT MAX(id) FROM Foo").ShouldBe(101);
+            await db.InsertAsync(new Foo { Value = 0 });
+            db.ExecuteScalar<int>("SELECT MAX(id) FROM Foo").ShouldBe(101);
         }
 
         [Fact]
         public async Task ShouldNotReseedId_TableWithSchema()
         {
-            await _database.ExecuteAsync("drop schema if exists A");
-            await _database.ExecuteAsync("create schema A");
-            await _database.ExecuteAsync("create table A.Foo ([id] [int] IDENTITY(1,1), Value int)");
+            using var db = await fixture.CreateDatabaseAsync();
+
+            await db.ExecuteAsync("drop schema if exists A");
+            await db.ExecuteAsync("create schema A");
+            await db.ExecuteAsync("create table A.Foo ([id] [int] IDENTITY(1,1), Value int)");
 
             for (int i = 0; i < 100; i++)
             {
-                await _database.ExecuteAsync("INSERT A.Foo VALUES (" + i + ")");
+                await db.ExecuteAsync("INSERT A.Foo VALUES (" + i + ")");
             }
 
-            _database.ExecuteScalar<int>("SELECT MAX(id) FROM A.Foo").ShouldBe(100);
+            db.ExecuteScalar<int>("SELECT MAX(id) FROM A.Foo").ShouldBe(100);
 
-            var checkpoint = await Respawner.CreateAsync(_connection, new RespawnerOptions
+            var checkpoint = await Respawner.CreateAsync(db.Connection, new RespawnerOptions
             {
                 WithReseed = false
             });
             try
             {
-                await checkpoint.ResetAsync(_connection);
+                await checkpoint.ResetAsync(db.Connection);
             }
             catch
             {
-                _output.WriteLine(checkpoint.ReseedSql);
+                output.WriteLine(checkpoint.ReseedSql);
                 throw;
             }
 
-            await _database.ExecuteAsync("INSERT A.Foo VALUES (0)");
-            _database.ExecuteScalar<int>("SELECT MAX(id) FROM A.Foo").ShouldBe(101);
+            await db.ExecuteAsync("INSERT A.Foo VALUES (0)");
+            db.ExecuteScalar<int>("SELECT MAX(id) FROM A.Foo").ShouldBe(101);
         }
 
         [Fact]
         public async Task ShouldReseedIdAccordingToIdentityInitialSeedValue()
         {
-            await _database.ExecuteAsync("create table Foo ([id] [int] IDENTITY(1001,1), Value int)");
+            using var db = await fixture.CreateDatabaseAsync();
 
-            await _database.InsertBulkAsync(Enumerable.Range(0, 100).Select(i => new Foo { Value = i }));
+            await db.ExecuteAsync("create table Foo ([id] [int] IDENTITY(1001,1), Value int)");
 
-            _database.ExecuteScalar<int>("SELECT MAX(id) FROM Foo").ShouldBe(1100);
+            await db.InsertBulkAsync(Enumerable.Range(0, 100).Select(i => new Foo { Value = i }));
 
-            var checkpoint = await Respawner.CreateAsync(_connection, new RespawnerOptions
+            db.ExecuteScalar<int>("SELECT MAX(id) FROM Foo").ShouldBe(1100);
+
+            var checkpoint = await Respawner.CreateAsync(db.Connection, new RespawnerOptions
             {
                 WithReseed = true
             });
 
             try
             {
-                await checkpoint.ResetAsync(_connection);
+                await checkpoint.ResetAsync(db.Connection);
             }
             catch
             {
-                _output.WriteLine(checkpoint.ReseedSql);
+                output.WriteLine(checkpoint.ReseedSql);
                 throw;
             }
 
-            await _database.InsertAsync(new Foo { Value = 0 });
-            _database.ExecuteScalar<int>("SELECT MAX(id) FROM Foo").ShouldBe(1001);
+            await db.InsertAsync(new Foo { Value = 0 });
+            db.ExecuteScalar<int>("SELECT MAX(id) FROM Foo").ShouldBe(1001);
         }
 
         [Fact]
         public async Task ShouldReseedIdAccordingToIdentityInitialSeedValue_TableWithSchema()
         {
-            await _database.ExecuteAsync("drop schema if exists A");
-            await _database.ExecuteAsync("create schema A");
-            await _database.ExecuteAsync("create table A.Foo ([id] [int] IDENTITY(1001,1), Value int)");
+            using var db = await fixture.CreateDatabaseAsync();
+
+            await db.ExecuteAsync("drop schema if exists A");
+            await db.ExecuteAsync("create schema A");
+            await db.ExecuteAsync("create table A.Foo ([id] [int] IDENTITY(1001,1), Value int)");
 
             for (int i = 0; i < 100; i++)
             {
-                await _database.ExecuteAsync("INSERT A.Foo VALUES (" + i + ")");
+                await db.ExecuteAsync("INSERT A.Foo VALUES (" + i + ")");
             }
 
-            _database.ExecuteScalar<int>("SELECT MAX(id) FROM A.Foo").ShouldBe(1100);
+            db.ExecuteScalar<int>("SELECT MAX(id) FROM A.Foo").ShouldBe(1100);
 
-            var checkpoint = await Respawner.CreateAsync(_connection, new RespawnerOptions
+            var checkpoint = await Respawner.CreateAsync(db.Connection, new RespawnerOptions
             {
                 WithReseed = true
             });
 
             try
             {
-                await checkpoint.ResetAsync(_connection);
+                await checkpoint.ResetAsync(db.Connection);
             }
             catch
             {
-                _output.WriteLine(checkpoint.ReseedSql);
+                output.WriteLine(checkpoint.ReseedSql);
                 throw;
             }
 
-            await _database.ExecuteAsync("INSERT A.Foo VALUES (0)");
-            _database.ExecuteScalar<int>("SELECT MAX(id) FROM A.Foo").ShouldBe(1001);
+            await db.ExecuteAsync("INSERT A.Foo VALUES (0)");
+            db.ExecuteScalar<int>("SELECT MAX(id) FROM A.Foo").ShouldBe(1001);
         }
 
         [Fact]
         public async Task ShouldReseedIdAccordingToIdentityInitialSeedValue_TableHasNeverHadAnyData()
         {
-            await _database.ExecuteAsync("create table Foo ([id] [int] IDENTITY(1001,1), Value int)");
+            using var db = await fixture.CreateDatabaseAsync();
 
-            var checkpoint = await Respawner.CreateAsync(_connection, new RespawnerOptions
+            await db.ExecuteAsync("create table Foo ([id] [int] IDENTITY(1001,1), Value int)");
+
+            var checkpoint = await Respawner.CreateAsync(db.Connection, new RespawnerOptions
             {
                 WithReseed = true
             });
 
             try
             {
-                await checkpoint.ResetAsync(_connection);
+                await checkpoint.ResetAsync(db.Connection);
             }
             catch
             {
-                _output.WriteLine(checkpoint.ReseedSql);
+                output.WriteLine(checkpoint.ReseedSql);
                 throw;
             }
 
-            await _database.InsertAsync(new Foo { Value = 0 });
-            _database.ExecuteScalar<int>("SELECT MAX(id) FROM Foo").ShouldBe(1001);
+            await db.InsertAsync(new Foo { Value = 0 });
+            db.ExecuteScalar<int>("SELECT MAX(id) FROM Foo").ShouldBe(1001);
         }
 
         [Fact]
         public async Task ShouldReseedIdAccordingToIdentityInitialSeedValue_TableWithSchemaHasNeverHadAnyData()
         {
-            await _database.ExecuteAsync("drop schema if exists A");
-            await _database.ExecuteAsync("create schema A");
-            await _database.ExecuteAsync("create table A.Foo ([id] [int] IDENTITY(1001,1), Value int)");
+            using var db = await fixture.CreateDatabaseAsync();
 
-            var checkpoint = await Respawner.CreateAsync(_connection, new RespawnerOptions
+            await db.ExecuteAsync("drop schema if exists A");
+            await db.ExecuteAsync("create schema A");
+            await db.ExecuteAsync("create table A.Foo ([id] [int] IDENTITY(1001,1), Value int)");
+
+            var checkpoint = await Respawner.CreateAsync(db.Connection, new RespawnerOptions
             {
                 WithReseed = true
             });
 
             try
             {
-                await checkpoint.ResetAsync(_connection);
+                await checkpoint.ResetAsync(db.Connection);
             }
             catch
             {
-                _output.WriteLine(checkpoint.ReseedSql);
+                output.WriteLine(checkpoint.ReseedSql);
                 throw;
             }
 
-            await _database.ExecuteAsync("INSERT A.Foo VALUES (0)");
-            _database.ExecuteScalar<int>("SELECT MAX(id) FROM A.Foo").ShouldBe(1001);
+            await db.ExecuteAsync("INSERT A.Foo VALUES (0)");
+            db.ExecuteScalar<int>("SELECT MAX(id) FROM A.Foo").ShouldBe(1001);
         }
 
         [Fact]
         public async Task ShouldDeleteTemporalTablesData()
         {
-            await _database.ExecuteAsync("drop table if exists FooHistory");
-            await _database.ExecuteAsync("IF OBJECT_ID(N'Foo', N'U') IS NOT NULL alter table Foo set (SYSTEM_VERSIONING = OFF)");
-            await _database.ExecuteAsync("drop table if exists Foo");
+            using var db = await fixture.CreateDatabaseAsync();
 
-            await _database.ExecuteAsync("create table Foo (Value [int] not null primary key clustered, " +
+            await db.ExecuteAsync("drop table if exists FooHistory");
+            await db.ExecuteAsync("IF OBJECT_ID(N'Foo', N'U') IS NOT NULL alter table Foo set (SYSTEM_VERSIONING = OFF)");
+            await db.ExecuteAsync("drop table if exists Foo");
+
+            await db.ExecuteAsync("create table Foo (Value [int] not null primary key clustered, " +
                                          "ValidFrom datetime2 generated always as row start, " +
                                          "ValidTo datetime2 generated always as row end," +
                                          " period for system_time(ValidFrom, ValidTo)" +
                                          ") with (system_versioning = on (history_table = dbo.FooHistory))");
 
-            await _database.ExecuteAsync("INSERT Foo (Value) VALUES (1)");
-            await _database.ExecuteAsync("UPDATE Foo SET Value = 2 Where Value = 1");
+            await db.ExecuteAsync("INSERT Foo (Value) VALUES (1)");
+            await db.ExecuteAsync("UPDATE Foo SET Value = 2 Where Value = 1");
 
-            var checkpoint = await Respawner.CreateAsync(_connection, new RespawnerOptions
+            var checkpoint = await Respawner.CreateAsync(db.Connection, new RespawnerOptions
             {
                 CheckTemporalTables = true
             });
-            await checkpoint.ResetAsync(_connection);
+            await checkpoint.ResetAsync(db.Connection);
 
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM FooHistory").ShouldBe(0);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM FooHistory").ShouldBe(0);
         }
 
         [Fact]
         public async Task ShouldResetTemporalTableDefaultName()
         {
-            await _database.ExecuteAsync("drop table if exists FooHistory");
-            await _database.ExecuteAsync("IF OBJECT_ID(N'Foo', N'U') IS NOT NULL alter table Foo set (SYSTEM_VERSIONING = OFF)");
-            await _database.ExecuteAsync("drop table if exists Foo");
+            using var db = await fixture.CreateDatabaseAsync();
 
-            await _database.ExecuteAsync("create table Foo (Value [int] not null primary key clustered, " +
+            await db.ExecuteAsync("drop table if exists FooHistory");
+            await db.ExecuteAsync("IF OBJECT_ID(N'Foo', N'U') IS NOT NULL alter table Foo set (SYSTEM_VERSIONING = OFF)");
+            await db.ExecuteAsync("drop table if exists Foo");
+
+            await db.ExecuteAsync("create table Foo (Value [int] not null primary key clustered, " +
                                          "ValidFrom datetime2 generated always as row start, " +
                                          "ValidTo datetime2 generated always as row end," +
                                          " period for system_time(ValidFrom, ValidTo)" +
                                          ") with (system_versioning = on (history_table = dbo.FooHistory))");
 
-            await _database.ExecuteAsync("INSERT Foo (Value) VALUES (1)");
-            await _database.ExecuteAsync("UPDATE Foo SET Value = 2 Where Value = 1");
+            await db.ExecuteAsync("INSERT Foo (Value) VALUES (1)");
+            await db.ExecuteAsync("UPDATE Foo SET Value = 2 Where Value = 1");
 
-            var checkpoint = await Respawner.CreateAsync(_connection, new RespawnerOptions
+            var checkpoint = await Respawner.CreateAsync(db.Connection, new RespawnerOptions
             {
                 CheckTemporalTables = true
             });
-            await checkpoint.ResetAsync(_connection);
+            await checkpoint.ResetAsync(db.Connection);
 
             var sql = @"
 SELECT t1.name 
 FROM sys.tables t1 
 WHERE t1.object_id = (SELECT history_table_id FROM sys.tables t2 WHERE t2.name = 'Foo')
 ";
-            _database.ExecuteScalar<string>(sql).ShouldBe("FooHistory");
+            db.ExecuteScalar<string>(sql).ShouldBe("FooHistory");
         }
 
         [Fact]
         public async Task ShouldResetTemporalTableAnonymousName()
         {
-            // _database.Execute("drop table if exists FooHistory");
-            await _database.ExecuteAsync("IF OBJECT_ID(N'Foo', N'U') IS NOT NULL alter table Foo set (SYSTEM_VERSIONING = OFF)");
-            await _database.ExecuteAsync("drop table if exists Foo");
+            using var db = await fixture.CreateDatabaseAsync();
 
-            await _database.ExecuteAsync("create table Foo (Value [int] not null primary key clustered, " +
+            // _database.Execute("drop table if exists FooHistory");
+            await db.ExecuteAsync("IF OBJECT_ID(N'Foo', N'U') IS NOT NULL alter table Foo set (SYSTEM_VERSIONING = OFF)");
+            await db.ExecuteAsync("drop table if exists Foo");
+
+            await db.ExecuteAsync("create table Foo (Value [int] not null primary key clustered, " +
                                          "ValidFrom datetime2 generated always as row start, " +
                                          "ValidTo datetime2 generated always as row end," +
                                          " period for system_time(ValidFrom, ValidTo)" +
                                          ") with (system_versioning = on)");
 
-            await _database.ExecuteAsync("INSERT Foo (Value) VALUES (1)");
-            await _database.ExecuteAsync("UPDATE Foo SET Value = 2 Where Value = 1");
+            await db.ExecuteAsync("INSERT Foo (Value) VALUES (1)");
+            await db.ExecuteAsync("UPDATE Foo SET Value = 2 Where Value = 1");
 
-            var checkpoint = await Respawner.CreateAsync(_connection, new RespawnerOptions
+            var checkpoint = await Respawner.CreateAsync(db.Connection, new RespawnerOptions
             {
                 CheckTemporalTables = true
             });
-            await checkpoint.ResetAsync(_connection);
+            await checkpoint.ResetAsync(db.Connection);
 
             var sql = @"
 SELECT t1.name 
 FROM sys.tables t1 
 WHERE t1.object_id = (SELECT history_table_id FROM sys.tables t2 WHERE t2.name = 'Foo')
 ";
-            _database.ExecuteScalar<string>(sql).ShouldStartWith("MSSQL_TemporalHistoryFor_");
+            db.ExecuteScalar<string>(sql).ShouldStartWith("MSSQL_TemporalHistoryFor_");
         }
 
         [Fact]
         public async Task ShouldDeleteTemporalTablesDataFromNotDefaultSchemas()
         {
-            await _database.ExecuteAsync("CREATE SCHEMA [TableSchema] AUTHORIZATION [dbo];");
-            await _database.ExecuteAsync("CREATE SCHEMA [HistorySchema] AUTHORIZATION [dbo];");
+            using var db = await fixture.CreateDatabaseAsync();
 
-            await _database.ExecuteAsync("create table TableSchema.Foo (Value [int] not null primary key clustered, " +
+            await db.ExecuteAsync("CREATE SCHEMA [TableSchema] AUTHORIZATION [dbo];");
+            await db.ExecuteAsync("CREATE SCHEMA [HistorySchema] AUTHORIZATION [dbo];");
+
+            await db.ExecuteAsync("create table TableSchema.Foo (Value [int] not null primary key clustered, " +
                                          "ValidFrom datetime2 generated always as row start, " +
                                          "ValidTo datetime2 generated always as row end," +
                                          " period for system_time(ValidFrom, ValidTo)" +
                                          ") with (system_versioning = on (history_table = HistorySchema.FooHistory))");
 
-            await _database.ExecuteAsync("INSERT TableSchema.Foo (Value) VALUES (1)");
-            await _database.ExecuteAsync("UPDATE TableSchema.Foo SET Value = 2 Where Value = 1");
+            await db.ExecuteAsync("INSERT TableSchema.Foo (Value) VALUES (1)");
+            await db.ExecuteAsync("UPDATE TableSchema.Foo SET Value = 2 Where Value = 1");
 
-            var checkpoint = await Respawner.CreateAsync(_connection, new RespawnerOptions
+            var checkpoint = await Respawner.CreateAsync(db.Connection, new RespawnerOptions
             {
                 CheckTemporalTables = true
             });
-            await checkpoint.ResetAsync(_connection);
+            await checkpoint.ResetAsync(db.Connection);
 
-            _database.ExecuteScalar<int>("SELECT COUNT(1) FROM HistorySchema.FooHistory").ShouldBe(0);
+            db.ExecuteScalar<int>("SELECT COUNT(1) FROM HistorySchema.FooHistory").ShouldBe(0);
         }
     }
 }

--- a/Respawn.sln
+++ b/Respawn.sln
@@ -13,6 +13,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		Build.ps1 = Build.ps1
 		.github\workflows\ci.yml = .github\workflows\ci.yml
 		Directory.Build.props = Directory.Build.props
+		Directory.Build.targets = Directory.Build.targets
 		informix-server\my_post.sh = informix-server\my_post.sh
 		informix-server\onconfig = informix-server\onconfig
 		Push.ps1 = Push.ps1


### PR DESCRIPTION
Using a fixture creates and starts a single container per test class instead of creating and starting one container per test.

Comparison of execution times on a MacBook Pro M2 Max.

DB2Tests: from about 1 hour to 6 minutes
MySqlTests: from 2 minutes down to 15 seconds
PostgresTests: from 45 seconds down to 6 seconds
SqlServerTests: from over 3 minutes down to 30 seconds

Note that two Informix tests are already failing with a DB2Exception, even before introducing the fixture (ShouldExcludeSchemas + ShouldIncludeSchemas)
> IBM.Data.Db2.DB2Exception
> ERROR [IX000] [IBM][IDS/UNIX64] User (a) was not found.